### PR TITLE
Supporting negative weights, take two

### DIFF
--- a/hybrasyl/Inventory.cs
+++ b/hybrasyl/Inventory.cs
@@ -352,7 +352,7 @@ namespace Hybrasyl
 
         public int Size { get; private set; }
         public int Count { get; private set; }
-        public ushort Weight { get; private set; }
+        public int Weight { get; private set; }
 
         #region Equipment Properties
 
@@ -611,6 +611,7 @@ namespace Hybrasyl
             Count += 1;
             Weight += item.Weight;
             _AddToIndex(item);
+
             return true;
         }
 
@@ -624,6 +625,7 @@ namespace Hybrasyl
             Count -= 1;
             Weight -= item.Weight;
             _RemoveFromIndex(item);
+
             return true;
         }
 

--- a/hybrasyl/Objects/Item.cs
+++ b/hybrasyl/Objects/Item.cs
@@ -116,9 +116,9 @@ namespace Hybrasyl.Objects
         {
             get { return (byte)Template.equip_slot; }
         }
-        public ushort Weight
+        public int Weight
         {
-            get { return (ushort)Template.weight; }
+            get { return Template.weight; }
         }
         public int MaximumStack
         {

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -219,9 +219,24 @@ namespace Hybrasyl.Objects
             }
         }
 
-        public ushort CurrentWeight
+        /**
+         * Returns the current weight as perceived by the client. The actual inventory or equipment
+         * weight may be less than zero, but this method will never return a negative value (negative
+         * values will appear as zero as the client expects).
+         */
+	public ushort VisibleWeight
+	{
+	    get { return (ushort)Math.Max(0, CurrentWeight); }
+	}
+
+        /**
+         * Returns the true weight of the user's inventory + equipment, which could be negative.
+         * Note that you should use VisibleWeight when communicating with the client since negative
+         * weights should be invisible to users.
+         */
+        public int CurrentWeight
         {
-            get { return (ushort) (Inventory.Weight + Equipment.Weight); }
+            get { return (Inventory.Weight + Equipment.Weight); }
         }
 
         public ushort MaximumWeight
@@ -955,7 +970,7 @@ namespace Hybrasyl.Objects
                     x08.WriteByte(0);
                 }
                 x08.WriteUInt16(MaximumWeight);
-                x08.WriteUInt16(CurrentWeight);
+                x08.WriteUInt16(VisibleWeight);
                 x08.WriteUInt32(uint.MinValue);
             }
             if (flags.HasFlag(StatUpdateFlags.Current))


### PR DESCRIPTION
See bug at https://hybrasyl.atlassian.net/browse/SERVER-69 and #6, a past pull request (obsolete).

This patch modifies how inventory weight is stored to support negative weights. Mark's diagnosis in the bug was correct; previously weight was being stored as an unsigned integer (meaning no negatives and it'd wrap around to a gigantic value if you tried).

Not a lot of notable changes here, but one explicit design decision work mentioning. I separated Inventory.CurrentWeight into two different properties: CurrentWeight (the true weight of the inventory, which could be negative), and VisibleWeight (which is never less than zero, intended to be displayed to the client). This introduces potential for bugs down the road since there are two ways to access the weight, though IMO this is the "right" way to do it since it allows for properly accounting for circumstances where the user goes from a negative weight to a positive weight (properly discounting the negative weight). For example, if you pick up items in the following order with the following weights:

[With single field] 1 + 1 - 2 - 2 + 1 = 1, since you effectively forget about everything < 0

[With two fields] 1 + 1 - 2 - 2 + 1 = -1, though displayed to the client as zero

I tested this by creating two items, one having positive weight and the other having negative. I've confirmed that items with negative weights can now be picked up, that they have the intended effect on the full inventory weight, and that picking up various sequences like the one shown above produce the proper values.