### PR TITLE
Support for grouping

### DIFF
--- a/hybrasyl/Hybrasyl.csproj
+++ b/hybrasyl/Hybrasyl.csproj
@@ -231,6 +231,7 @@
     <Compile Include="Server.cs" />
     <Compile Include="Template.cs" />
     <Compile Include="Objects\User.cs" />
+    <Compile Include="UserGroup.cs" />
     <Compile Include="Utility.cs" />
     <Compile Include="World.cs" />
     <Compile Include="Objects\WorldObject.cs" />

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -143,6 +143,11 @@ namespace Hybrasyl.Objects
         public string LastSaid { get; set; }
         public int NumSaidRepeated { get; set; }
 
+        public bool Grouped
+        {
+            get { return Group != null; }
+        }
+
         // this is terrible and I hate it. It will go away soon.
         // HAHAHAHAHAHA LIES.
 
@@ -273,6 +278,20 @@ namespace Hybrasyl.Objects
                 LoadDataFromEntityFramework();
             }
 
+        }
+
+        /**
+         * Invites another user to this user's group. If this user isn't in a group,
+         * create a new one.
+         */
+        public bool InviteToGroup(User invitee)
+        {
+            if (!Grouped)
+            {
+                Group = new UserGroup(this);
+            }
+
+            return Group.Add(invitee);
         }
 
         /**
@@ -1453,6 +1472,8 @@ namespace Hybrasyl.Objects
                 profilePacket.WriteString8(mark.prefix);
                 profilePacket.WriteString8(mark.text);
             }
+
+            // TODO: should show list of group members here.
 
             Enqueue(profilePacket);
         }

--- a/hybrasyl/UserGroup.cs
+++ b/hybrasyl/UserGroup.cs
@@ -1,0 +1,157 @@
+/*
+ * This file is part of Project Hybrasyl.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the Affero General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * without ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2013 Justin Baugh (baughj@hybrasyl.com)
+ * (C) 2015 Project Hybrasyl (info@hybrasyl.com)
+ *
+ * Authors:   Luke Segars   <luke@lukesegars.com>
+ */
+
+using Hybrasyl.Objects;
+using Hybrasyl.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using log4net;
+
+namespace Hybrasyl
+{
+    /**
+     * This class defines a group of users.
+     */
+    public class UserGroup
+    {
+        public static readonly ILog Logger =
+            LogManager.GetLogger(
+            System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        // Group-related info
+        public List<User> Members { get; private set; }
+        public DateTime CreatedOn { get; private set; }
+        public Dictionary<Class, uint> ClassCount { get; private set; }
+
+        private delegate Dictionary<uint, int> DistributionFunc(User source, int full);
+        private DistributionFunc ExperienceDistributionFunc;
+
+        public UserGroup(User founder)
+        {
+            Logger.Debug("Creating new group.");
+            // Distribute full experience to everyone.
+            ExperienceDistributionFunc = Distribution_AllClassBonus;
+            Add(founder);
+
+            CreatedOn = DateTime.Now;
+        }
+
+        // TODO: remove this one i've confirmed that groups are actually being deleted.
+        ~UserGroup()
+        {
+            Logger.Debug("Cleaning up group.");
+        }
+
+        // Group-related functions and accessors
+        public void Add(User user)
+        {
+            // Send a message to notify everyone else that someone's joined.
+            foreach (var member in Members)
+            {
+                member.SendMessage(user.Name + " has joined your group.", MessageTypes.SYSTEM);
+            }
+
+            Members.Add(user);
+            user.Group = this;
+            ClassCount[user.Class]++;
+
+            // Send a special message to the new user. This is different than how USDA does it but
+            // provides more flexibility.
+            user.SendMessage("You've joined a group.", MessageTypes.SYSTEM);
+        }
+
+        public void Remove(User user)
+        {
+            Members.Remove(user);
+            user.Group = null;
+            ClassCount[user.Class]--;
+
+            foreach (var member in Members)
+            {
+                member.SendMessage(user.Name + " has left your group.", MessageTypes.SYSTEM);
+            }
+            user.SendMessage("You've left a group.", MessageTypes.SYSTEM);
+
+            // If there's only one person left, disband the grounp.
+            if (Count == 1)
+            {
+                Remove(Members[0]);
+            }
+        }
+
+        public int Count
+        {
+            get { return Members.Count; }
+        }
+
+        public bool ContainsAllClasses()
+        {
+            return (ClassCount[Enums.Class.Monk] > 0 &&
+                ClassCount[Enums.Class.Priest] > 0 &&
+                ClassCount[Enums.Class.Rogue] > 0 &&
+                ClassCount[Enums.Class.Warrior] > 0 &&
+                ClassCount[Enums.Class.Wizard] > 0);
+        }
+
+        /**
+         * Distribute a pool of experience across members of the group.
+         */
+        public void ShareExperience(User source, int experience)
+        {
+            Dictionary<uint, int> share = ExperienceDistributionFunc(source, experience);
+
+            for (int i = 0; i < Members.Count; i++)
+            {
+                // Note: this will only work for positive numbers at this point.
+                Members[i].GiveExperience((uint)share[Members[i].Id]);
+            }
+        }
+
+        /**
+         * Distribution functions. Should be assigned to ExperienceDistributionFunc or a similar
+         * function to be put to use. See the constructor of UserGroup for an example.
+         */
+        private Dictionary<uint, int> Distribution_Full(User source, int full)
+        {
+            Dictionary<uint, int> share = new Dictionary<uint, int>();
+
+            foreach (var member in Members)
+            {
+                share[member.Id] = full;
+            }
+
+            return share;
+        }
+
+        private Dictionary<uint, int> Distribution_AllClassBonus(User source, int full)
+        {
+            // Check to see if at least one representative from each class is in the group.
+            if (ContainsAllClasses())
+            {
+                full = (int)(full * 1.10);
+            }
+
+            return Distribution_Full(source, full);
+        }
+    }
+}

--- a/hybrasyl/Utility.cs
+++ b/hybrasyl/Utility.cs
@@ -231,6 +231,9 @@ namespace Hybrasyl
         public const uint MAXIMUM_GOLD = 1000000000;
         public const int VARIANT_ID_START = 100000;
         public const int DEFAULT_LOG_LEVEL = Hybrasyl.LogLevels.INFO;
+        // Manhattan distance between the user performing an action (killing a monster, etc) and other
+        // users in the group in order to be eligible for sharing.
+        public const int GROUP_SHARING_DISTANCE = 20;
         public const string EF_METADATA = "metadata=res://*/Properties.Hybrasyl.csdl|res://*/Properties.Hybrasyl.ssdl|res://*/Properties.Hybrasyl.msl;provider=MySql.Data.MySqlClient;";
         public const string EF_CONNSTRING_TEMPLATE = @"provider connection string=""server={0};user id={1};password={2};convertzerodatetime=true;allowzerodatetime=true;persist security info=True;database={3}""";
 

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -2059,13 +2059,13 @@ namespace Hybrasyl
                 // That means we need to check whether the user is a valid candidate for
                 // grouping, and send the confirmation dialog if so.
                 case 0x02:
-                    Logger.InfoFormat("{0} invites {1} to join a group.", user.Name, partner.Name);
+                    Logger.DebugFormat("{0} invites {1} to join a group.", user.Name, partner.Name);
                     
                     // Remove the user from the group. Kinda logically weird beside all of this other stuff 
                     // so it may be worth restructuring but it should be accurate as-is.
                     if (partner.Grouped && user.Grouped && partner.Group == user.Group)
                     {
-                        Logger.InfoFormat("{0} leaving group.", user.Name);
+                        Logger.DebugFormat("{0} leaving group.", user.Name);
                         user.Group.Remove(partner);
                         return;
                     }
@@ -2097,12 +2097,12 @@ namespace Hybrasyl
                 // request. We need to add them to the original user's group. Note that in this
                 // case the partner sent the original invitation.
                 case 0x03:
-                    Logger.Info("Invitation accepted. Grouping.");
+                    Logger.Debug("Invitation accepted. Grouping.");
                     partner.InviteToGroup(user);
                     break;
                 // This shouldn't happen but we should log it and fix it if it does.
                 default:
-                    Logger.Info("Unknown GroupRequest stage. No action taken.");
+                    Logger.Error("Unknown GroupRequest stage. No action taken.");
                     break;
             }
         }
@@ -2121,7 +2121,8 @@ namespace Hybrasyl
             user.Grouping = !user.Grouping;
             user.Save();
 
-            // TODO: Is there any packet content that needs to be used on the server?
+            // TODO: Is there any packet content that needs to be used on the server? It appears there
+            // are extra bytes coming through but not sure what purpose they serve.
         }
 
         private void PacketHandler_0x2A_DropGoldOnCreature(Object obj, ClientPacket packet)


### PR DESCRIPTION
This is a pretty big one so I've broken it up into three revisions for review. Happy to collapse them later.

A general overview of the design is here: https://docs.google.com/document/d/1aIjHNzWSw3Y1Zm3ndEjmkV4yjL2hUlxaQJo_aGI_dgE/edit#. Note that I wrote this up beforehand so there may be some slight discrepancies.

This PR introduces the UserGroup class, which represents groups of users that can communicate together (via group whisper) and share resources (such as experience). A few things to note:

   - This introduces support for two opcodes: **0x2E** (called GroupRequest) and **0x2F** (called GroupToggle).
   - Group joining / leaving interactions have been kept as similar as I could to what USDA does, with the exception of some messaging. Certain messages are changed to strings that are more sensible ("You've joined a group" instead of "<your name> has joined a group", for example).
   - This introduces a new constant called **GROUP_SHARING_DISTANCE** that defines the maximum Manhattan distance between a user and an event (death of a monster) where the user will be eligible to share in the spoils.
   - This introduces a new experience function called **ShareExperience** that calls a distribution function if the user is grouped or falls back to **GiveExperience** if not. The intent is that this function would be called whenever experience should be shared if a user is grouped (hunting, etc), but GiveExperience would be used whenever experience shouldn't be shared despite group status (solo quests, etc).
   - Whisper handling now branches depending on the name of the target. If the name == "!!" (magic sequence from USDA) then it's a group whisper, otherwise it's a direct whisper. I abstracted a bit of pre-existing logic to make sure that muting rules are shared between group and direct whispers.
   - Added /group, /ungroup, and /exp commands to make all of this stuff easier to test.
   - Resource distribution functions are intended to be easy to extend and modify (though they're not scripted, so they still need to be compiled in). Could be a good candidate for scripting in the future (maybe?).

Thoughts welcome; thanks! Probably going to make another cleanup pass on this but wanted to get some feedback on the general design and whether there were any obvious missing pieces as well.