### PR TITLE
[server-170] Implement legend mark support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Hybrasyl Server 0.5.1
+
+* Sample XML data updated.
+* Documentation updates.
+* Bug fixed where the server would write out incorrect XML, causing the login/world port to be the same.
+* Added support for server (Aisling) time.
+
 # Hybrasyl Server 0.5.0 ("Riona")
 
 * Redis is now a requirement, and is used for storing state data such as users, board posts, and mailboxes.

--- a/hybrasyl/Enums.cs
+++ b/hybrasyl/Enums.cs
@@ -26,6 +26,36 @@ namespace Hybrasyl
 {
     namespace Enums
     {
+        public enum LegendIcon
+        {
+            Community = 0,
+            Warrior = 1,
+            Rogue = 2,
+            Wizard = 3,
+            Priest = 4,
+            Monk = 5,
+            Heart = 6,
+            Victory = 7
+        }
+
+        public enum LegendColor
+        {
+            White = 32,
+            LightOrange = 50,
+            LightYellow = 64,
+            Yellow = 68,
+            LightGreen = 75,
+            Blue = 88,
+            LightPink = 96,
+            DarkPurple = 100,
+            Pink = 105,
+            Darkgreen = 125,
+            Green = 128,
+            Orange = 152,
+            Brown = 160,
+            Red = 248
+        }
+
         //this is a wip
         internal static class OpCodes
         {
@@ -77,7 +107,6 @@ namespace Hybrasyl
             public const byte MetaData = 0x6F;
 
         }
-
 
         public enum PrivateMessageType : int
         {

--- a/hybrasyl/Hybrasyl.csproj
+++ b/hybrasyl/Hybrasyl.csproj
@@ -138,6 +138,7 @@
   <ItemGroup>
     <Compile Include="Book.cs" />
     <Compile Include="Board.cs" />
+    <Compile Include="Legend.cs" />
     <Compile Include="Time.cs" />
     <Compile Include="Client.cs" />
     <Compile Include="Connection.cs" />

--- a/hybrasyl/Legend.cs
+++ b/hybrasyl/Legend.cs
@@ -1,4 +1,25 @@
-﻿using System;
+﻿/*
+ * This file is part of Project Hybrasyl.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the Affero General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * without ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2016 Project Hybrasyl (info@hybrasyl.com)
+ *
+ * Authors:   Justin Baugh  <baughj@hybrasyl.com>
+ *
+ */
+ 
+ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;

--- a/hybrasyl/Legend.cs
+++ b/hybrasyl/Legend.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Hybrasyl.Enums;
+using Newtonsoft.Json;
+
+namespace Hybrasyl
+{
+
+    [JsonObject(MemberSerialization.OptIn)]
+    public class Legend : IEnumerable<LegendMark>
+    {
+        public const int MaximumLegendSize = 254;
+
+        [JsonProperty] private SortedDictionary<DateTime, LegendMark> _legend =
+            new SortedDictionary<DateTime, LegendMark>();
+
+        private Dictionary<string, LegendMark> _legendIndex = new Dictionary<string, LegendMark>();
+
+        public bool TryGetMark(string prefix, out LegendMark mark)
+        {
+            return _legendIndex.TryGetValue(prefix, out mark);
+        }
+
+        private bool _addLegendMark(LegendMark mark)
+        {
+            if (_legend.Keys.Count == MaximumLegendSize) return false;
+            if (!string.IsNullOrEmpty(mark.Prefix) && _legendIndex.ContainsKey(mark.Prefix))
+                throw new ArgumentException("A legend mark's prefix must be unique for a given character");
+            _legend.Add(mark.Created, mark);
+            _legendIndex[mark.Prefix] = mark;
+            return true;
+        }
+
+        public bool RemoveMark(string prefix)
+        {
+            LegendMark mark;
+            if (!_legendIndex.TryGetValue(prefix, out mark)) return false;
+            _legendIndex.Remove(prefix);
+            _legend.Remove(mark.Created);
+            return true;
+        }
+
+        public bool AddMark(LegendIcon icon, LegendColor color, string text, DateTime created,
+            string prefix = default(string), bool isPublic = true, int quantity = 0)
+        {
+            var newMark = new LegendMark(icon, color, text, created, prefix, isPublic, quantity);
+            return _addLegendMark(newMark);
+        }
+
+        public bool AddMark(LegendIcon icon, LegendColor color, string text, string prefix = default(string),
+            bool isPublic = true, int quantity = 0)
+        {
+            var datetime = DateTime.Now;
+            var newMark = new LegendMark(icon, color, text, datetime, prefix, isPublic, quantity);
+            return _addLegendMark(newMark);
+        }
+
+        public void RegenerateIndex()
+        {
+            if (_legendIndex.Count == _legend.Count) return;
+            _legendIndex = new Dictionary<string, LegendMark>();
+            foreach (var kvp in _legend)
+            {
+                _legendIndex[kvp.Value.Prefix] = kvp.Value;
+            }
+        }
+
+        public void Clear()
+        {
+            _legendIndex = new Dictionary<string, LegendMark>();
+            _legend = new SortedDictionary<DateTime, LegendMark>();
+        }
+
+        public int Count => _legend.Count;
+
+        public IEnumerator<LegendMark> GetEnumerator()
+        {
+            return _legend.Values.ToList().GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+
+    [JsonObject]
+    public class LegendMark
+    {
+        public string Prefix { get; set; }
+        public LegendColor Color { get; set; }
+        public LegendIcon Icon { get; set; }
+        public string Text { get; set; }
+        public bool Public { get; set; }
+        public DateTime Created { get; set; }
+        public int Quantity { get; set; }
+
+        public LegendMark(LegendIcon icon, LegendColor color, string text, DateTime created,
+            string prefix = default(string), bool isPublic = true, int quantity = 0)
+        {
+            Icon = icon;
+            Color = color;
+            Text = text;
+            Public = isPublic;
+            Quantity = quantity;
+            Prefix = prefix;
+            Created = created;
+        }
+
+        public override string ToString()
+        {
+            var aislingDate = HybrasylTime.ConvertToHybrasyl(Created);
+            var returnString = Text;
+            var markDate = $"{aislingDate.Age} {aislingDate.Year}, {aislingDate.Season}";
+
+            var maxLength = 254 - 15 - markDate.Length;
+
+            if (Text.Length > maxLength)
+            {
+                returnString = Text.Substring(0, maxLength);
+            }
+
+            if (Quantity != 0)
+                returnString = $"{returnString} ({Quantity})";
+            if (!Public)
+                returnString = $" - {returnString}";
+
+            returnString = $"{returnString} - {markDate}";
+            return returnString;
+
+        }
+    }
+}

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -35,21 +35,55 @@ using Hybrasyl.XSD;
 namespace Hybrasyl.Objects
 {
 
+
     [JsonObject]
     public class LegendMark
     {
         public String Prefix { get; set; }
-        public int Color { get; set; }
-        public int Icon { get; set; }
+        public LegendColor Color { get; set; }
+        public LegendIcon Icon { get; set; }
         public String Text { get; set; }
         public bool Public { get; set; }
         public DateTime Created { get; set; }
         public int Quantity { get; set; }
-        /*
+
+        public LegendMark()
+        {           
+        }
+
+        public LegendMark(LegendIcon icon, LegendColor color, string text, DateTime created, string prefix="HYB", bool isPublic = true, int quantity = 0)
+        {
+            Icon = icon;
+            Color = color;
+            Text = text;
+            Public = isPublic;
+            Quantity = quantity;
+            Prefix = prefix;
+            Created = created;
+        }
+
         public override string ToString()
         {
-            //var ingame = World.TimeConverter.AsString(Created, bool fullTime = false)
-        }*/
+            var aislingDate = HybrasylTime.ConvertToHybrasyl(Created);
+            var returnString = Text;
+            var markDate = $"{aislingDate.Age} {aislingDate.Year}, {aislingDate.Season}";
+
+            var maxLength = 254 - 15 - markDate.Length;
+
+            if (Text.Length > maxLength)
+            {
+                returnString = Text.Substring(0, maxLength);
+            }
+
+            if (Quantity != 0)
+                returnString = $"{returnString} ({Quantity})";
+            if (!Public)
+                returnString = $" - {returnString}";
+
+            returnString = $"{returnString} - {markDate}";
+            return returnString;
+
+        }
     }
 
     [JsonObject]
@@ -240,6 +274,10 @@ namespace Hybrasyl.Objects
                 return span.TotalSeconds < 0 ? 0 : span.TotalSeconds;
             }
         }
+
+        public string SinceLastLoginString => SinceLastLogin < 86400 ? 
+            $"{Math.Floor(SinceLastLogin/3600)} hours, {Math.Floor(SinceLastLogin%3600/60)} minutes" : 
+            $"{Math.Floor(SinceLastLogin/86400)} days, {Math.Floor(SinceLastLogin%86400/3600)} hours, {Math.Floor(SinceLastLogin%86400%3600)/60} minutes";
 
         // Throttling checks for messaging
 
@@ -702,6 +740,8 @@ namespace Hybrasyl.Objects
             profilePacket.WriteByte((byte)Legend.Count );
             foreach (var mark in Legend)
             {
+                if (!mark.Public)
+                    continue;
                 profilePacket.WriteByte((byte)mark.Icon);
                 profilePacket.WriteByte((byte)mark.Color);
                 profilePacket.WriteString8(mark.Prefix);
@@ -1803,7 +1843,7 @@ namespace Hybrasyl.Objects
                 profilePacket.WriteByte((byte) mark.Icon);
                 profilePacket.WriteByte((byte) mark.Color);
                 profilePacket.WriteString8(mark.Prefix);
-                profilePacket.WriteString8(mark.Text);
+                profilePacket.WriteString8(mark.ToString());
             }
 
             Enqueue(profilePacket);
@@ -2308,51 +2348,5 @@ namespace Hybrasyl.Objects
             Client.SendMessage(p, 3);
         }
 
-
-        /*
-        [SecurityPermission(SecurityAction.Demand, SerializationFormatter =true)]
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            info.AddValue("SerializationVersion", "1");
-            info.AddValue("Name", Name);
-            info.AddValue("Sex", Sex);
-            info.AddValue("HairStyle", HairStyle);
-            info.AddValue("HairColor", HairColor);
-            info.AddValue("Class", Class);
-            info.AddValue("Level", Level);
-            info.AddValue("LevelPoints", LevelPoints);
-            info.AddValue("Experience", Experience);
-            info.AddValue("Ability", Ability);
-            info.AddValue("MapId", MapId);
-            info.AddValue("MapX", MapX);
-            info.AddValue("AbilityExp", AbilityExp);
-            info.AddValue("BaseHp", BaseHp);
-            info.AddValue("BaseMp", BaseMp);
-            info.AddValue("Hp", Hp);
-            info.AddValue("Mp", Mp);
-            info.AddValue("BaseStr", BaseStr);
-            info.AddValue("BaseInt", BaseStr);
-            info.AddValue("BaseWis", BaseStr);
-            info.AddValue("BaseDex", BaseStr);
-            info.AddValue("BaseCon", BaseStr);
-            info.AddValue("Gold", Gold);
-            info.AddValue("IsMaster", IsMaster);
-            info.AddValue("Dead", Dead);
-            info.AddValue("Grouping", Grouping);
-            info.AddValue("PortraitData", PortraitData);
-            info.AddValue("ProfileText", ProfileText);
-            info.AddValue("LoginTime", LoginTime);
-            info.AddValue("LogoffTime", LogoffTime);
-            info.AddValue("UserFlags", UserFlags);
-            info.AddValue("PlayerStatus", Status);
-                
-            info.AddValue("LegendMarks", Legend);
-            info.AddValue("Inventory", Inventory, typeof(Inventory));
-            info.AddValue("Equipment", Equipment, typeof(Inventory));
-
-
-
-
-        }*/
     }
 }

--- a/hybrasyl/Time.cs
+++ b/hybrasyl/Time.cs
@@ -1,4 +1,25 @@
-﻿using System;
+﻿/*
+ * This file is part of Project Hybrasyl.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the Affero General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * without ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2016 Project Hybrasyl (info@hybrasyl.com)
+ *
+ * Authors:   Justin Baugh  <baughj@hybrasyl.com>
+ *
+ */
+ 
+ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -19,6 +40,34 @@ namespace Hybrasyl
         public int Sun;
         public int Hour;
         public int Minute;
+
+        public string Season
+        {
+            get
+            {
+                switch (Moon)
+               {
+                    case 12:
+                    case 1:
+                    case 2:
+                       return "Winter";
+                    case 3:
+                    case 4:
+                    case 5:
+                        return "Spring";
+                    case 6:
+                    case 7:
+                    case 8:
+                        return "Summer";
+                    case 9:
+                    case 10:
+                    case 11:
+                        return "Fall";
+                    default:
+                       return String.Empty;
+               }
+            }
+        }
 
         public const long YearTicks = 12 * MoonTicks;
         public const long MoonTicks = 28 * SunTicks;

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -41,11 +41,8 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Timers;
-using System.Windows.Forms;
 using System.Xml;
 using System.Xml.Schema;
-using IronPython.Modules;
-using Microsoft.Win32.SafeHandles;
 using Newtonsoft.Json;
 using StackExchange.Redis;
 
@@ -1511,7 +1508,24 @@ namespace Hybrasyl
                         }
                     }
                         break;
+                    case "/legend":
+                    {
+                        var icon = (LegendIcon) Enum.Parse(typeof(LegendIcon), args[1]);
+                        var color =(LegendColor) Enum.Parse(typeof(LegendColor), args[2]);
+                        var quantity = Int32.Parse(args[3]);
+                        var datetime = DateTime.Parse(args[4]);
+                        
+                        var legend = string.Join(" ", args, 4, args.Length - 4);
+                        user.Legend.Add(new LegendMark(icon, color, legend, datetime, "HYB", true, quantity));
+                    }
+                        break;
 
+                    case "/legendclear":
+                    {
+                        user.Legend.Clear();
+                        user.SendSystemMessage("Legend has been cleared.");
+                    }
+                        break;
                     case "/level":
                     {
                         byte newLevel;
@@ -2129,7 +2143,6 @@ namespace Hybrasyl
            
             Logger.DebugFormat("Elapsed time since login: {0}", loginUser.SinceLastLogin);
 
-
             if (loginUser.Nation.Spawnpoints.Count != 0 &&
                 loginUser.SinceLastLogin > Hybrasyl.Constants.NATION_SPAWN_TIMEOUT)
             {
@@ -2154,6 +2167,9 @@ namespace Hybrasyl
             ActiveUsers[connectionId] = loginUser;
             ActiveUsersByName[loginUser.Name] = connectionId;
             Logger.InfoFormat("cid {0}: {1} entering world", connectionId, loginUser.Name);
+            Logger.InfoFormat($"{loginUser.SinceLastLoginString}");
+            loginUser.SendSystemMessage($"It has been {loginUser.SinceLastLoginString} since your last login.");
+            loginUser.SendSystemMessage(HybrasylTime.Now().ToString());
         }
 
         private void PacketHandler_0x18_ShowPlayerList(Object obj, ClientPacket packet)

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -1515,8 +1515,8 @@ namespace Hybrasyl
                         var quantity = Int32.Parse(args[3]);
                         var datetime = DateTime.Parse(args[4]);
                         
-                        var legend = string.Join(" ", args, 4, args.Length - 4);
-                        user.Legend.Add(new LegendMark(icon, color, legend, datetime, "HYB", true, quantity));
+                        var legend = string.Join(" ", args, 5, args.Length - 5);
+                        user.Legend.AddMark(icon, color, legend, datetime, string.Empty, true, quantity);
                     }
                         break;
 
@@ -2170,6 +2170,7 @@ namespace Hybrasyl
             Logger.InfoFormat($"{loginUser.SinceLastLoginString}");
             loginUser.SendSystemMessage($"It has been {loginUser.SinceLastLoginString} since your last login.");
             loginUser.SendSystemMessage(HybrasylTime.Now().ToString());
+            loginUser.Reindex();
         }
 
         private void PacketHandler_0x18_ShowPlayerList(Object obj, ClientPacket packet)

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -1512,7 +1512,7 @@ namespace Hybrasyl
                     {
                         var icon = (LegendIcon) Enum.Parse(typeof(LegendIcon), args[1]);
                         var color =(LegendColor) Enum.Parse(typeof(LegendColor), args[2]);
-                        var quantity = Int32.Parse(args[3]);
+                        var quantity = int.Parse(args[3]);
                         var datetime = DateTime.Parse(args[4]);
                         
                         var legend = string.Join(" ", args, 5, args.Length - 5);


### PR DESCRIPTION
This PR extends the legend mark support to use a new container `Legend` which supports enumeration and also exposes a public API that can be used by scripting. Legend marks have a `ToString` override that builds a display string based on whether or not a mark is public (private appends ` - ` to a mark and will only display to the user with the mark), quantity (e.g. `Herp Derp (38) - Hybrasyl 1, Winter`), and date. The date can be any date that Hybrasyl knows about via the time configuration (so marks can extend across a number of defined ages). Legend mark dates are stored as Terran dates and converted to Aisling dates when needed.

Prefixes are essentially string keys that can be used to identify legend marks later; their function from commercial is carried over here. A separate index is used for this purpose in the `Legend` structure.

Two enums are introduced for convenience as well, `LegendIcon` and `LegendColor`, especially since Color is somewhat nonsensical from an integer point of view.

cc: @norrismiv 