### PR TITLE
[SERVER-171] Add Python API support for legend marks

### DIFF
--- a/hybrasyl/Legend.cs
+++ b/hybrasyl/Legend.cs
@@ -115,7 +115,7 @@ namespace Hybrasyl
         public LegendIcon Icon { get; set; }
         public string Text { get; set; }
         public bool Public { get; set; }
-        public DateTime Created { get; set; }
+        public DateTime Created { get; }
         public int Quantity { get; set; }
 
         public LegendMark(LegendIcon icon, LegendColor color, string text, DateTime created,

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -234,7 +234,7 @@ namespace Hybrasyl.Objects
 
         public string SinceLastLoginString => SinceLastLogin < 86400 ? 
             $"{Math.Floor(SinceLastLogin/3600)} hours, {Math.Floor(SinceLastLogin%3600/60)} minutes" : 
-            $"{Math.Floor(SinceLastLogin/86400)} days, {Math.Floor(SinceLastLogin%86400/3600)} hours, {Math.Floor(SinceLastLogin%86400%3600)/60} minutes";
+            $"{Math.Floor(SinceLastLogin/86400)} days, {Math.Floor(SinceLastLogin%86400/3600)} hours, {Math.Floor(SinceLastLogin%86400%3600/60)} minutes";
 
         // Throttling checks for messaging
 

--- a/hybrasyl/Objects/WorldObject.cs
+++ b/hybrasyl/Objects/WorldObject.cs
@@ -60,39 +60,18 @@ namespace Hybrasyl.Objects
         public WorldObject()
         {
             Name = string.Empty;
+            ResetPursuits();
         }
 
         public virtual void SendId()
         {
         }
-    }
 
-    public class VisibleObject : WorldObject
-    {
-        public new static readonly ILog Logger =
-               LogManager.GetLogger(
-               System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
-
-        public Map Map { get; set; }
-        public Direction Direction { get; set; }
-        public ushort Sprite { get; set; }
-        public String Portrait { get; set; }
-        public string DisplayText { get; set; }
-
-        public List<DialogSequence> Pursuits;
-        public List<DialogSequence> DialogSequences;
-        public Dictionary<String, DialogSequence> SequenceCatalog;
-
-        public VisibleObject()
+        public void ResetPursuits()
         {
             Pursuits = new List<DialogSequence>();
             DialogSequences = new List<DialogSequence>();
-            SequenceCatalog = new Dictionary<String, DialogSequence>();
-            DisplayText = String.Empty;
-        }
-
-        public virtual void AoiEntry(VisibleObject obj)
-        {
+            SequenceCatalog = new Dictionary<string, DialogSequence>();
         }
 
         public virtual void AddPursuit(DialogSequence pursuit)
@@ -110,6 +89,13 @@ namespace Hybrasyl.Objects
                 Pursuits.Add(pursuit);
             }
 
+            if (SequenceCatalog.ContainsKey(pursuit.Name))
+            {
+                Logger.WarnFormat("Pursuit {0} is being overwritten", pursuit.Name);
+                SequenceCatalog.Remove(pursuit.Name);
+
+            }
+
             SequenceCatalog.Add(pursuit.Name, pursuit);
 
             if (pursuit.Id > Constants.DIALOG_SEQUENCE_SHARED)
@@ -122,7 +108,41 @@ namespace Hybrasyl.Objects
         {
             sequence.Id = (uint)(Constants.DIALOG_SEQUENCE_PURSUITS + DialogSequences.Count);
             DialogSequences.Add(sequence);
+            if (SequenceCatalog.ContainsKey(sequence.Name))
+            {
+                Logger.WarnFormat("Dialog sequence {0} is being overwritten", sequence.Name);
+                SequenceCatalog.Remove(sequence.Name);
+
+            }
             SequenceCatalog.Add(sequence.Name, sequence);
+        }
+
+        public List<DialogSequence> Pursuits;
+        public List<DialogSequence> DialogSequences;
+        public Dictionary<String, DialogSequence> SequenceCatalog;
+    }
+
+    public class VisibleObject : WorldObject
+    {
+        public new static readonly ILog Logger =
+               LogManager.GetLogger(
+               System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        public Map Map { get; set; }
+        public Direction Direction { get; set; }
+        public ushort Sprite { get; set; }
+        public String Portrait { get; set; }
+        public string DisplayText { get; set; }
+
+
+        public VisibleObject()
+        {
+          
+            DisplayText = String.Empty;
+        }
+
+        public virtual void AoiEntry(VisibleObject obj)
+        {
         }
 
         public virtual void AoiDeparture(VisibleObject obj)

--- a/hybrasyl/Scripting.cs
+++ b/hybrasyl/Scripting.cs
@@ -590,7 +590,7 @@ from System import DateTime
         public dynamic GetLegendMark(string prefix)
         {
             LegendMark mark;
-            return User.Legend.TryGetMark(prefix, out mark) ? mark : null;
+            return User.Legend.TryGetMark(prefix, out mark) ? mark : (object)null;
         }
 
         public Legend GetLegend()


### PR DESCRIPTION
This PR adds Python API support for legend marks: `GetLegend`, `GetLegendMark`, `RemoveLegendMark`, and `ModifyLegendMark`. These can be used by NPCs or other scripts to modify a player's legend.

Also included: refactoring to scripting / script handlers to allow `/scripting reload riona.py` to work as expected, renaming `String` to `string`, and fixing a formatting bug when time since last login is displayed to the user.

cc: @norrismiv
