### PR TITLE
Ensure item bonuses are recalculated on login (resolves #42)

### DIFF
--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -1398,6 +1398,13 @@ namespace Hybrasyl.Objects
         {
             return RemoveGold(gold.Amount);
         }
+
+        public void RecalculateBonuses()
+        {
+            foreach (var item in Equipment)
+                ApplyBonuses(item);            
+        }
+
         public bool RemoveGold(uint amount)
         {
             Logger.DebugFormat("Removing {0} gold", amount);

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -2134,6 +2134,7 @@ namespace Hybrasyl
             loginUser.UpdateLoginTime();
             loginUser.Inventory.RecalculateWeight();
             loginUser.Equipment.RecalculateWeight();
+            loginUser.RecalculateBonuses();
             loginUser.UpdateAttributes(StatUpdateFlags.Full);
             loginUser.SendInventory();
             loginUser.SendEquipment();


### PR DESCRIPTION
This fixes a bug where we are not properly recalculating things like AC/MR/etc at login because deserializing Equipment doesn't result in bonuses / etc being applied. 

A better long term fix for this is to handle it in the deserializer itself but this will do for now.

cc: @norrismiv 