### PR TITLE
[SERVER-158] Fix level / experience overflows

### DIFF
--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -181,10 +181,11 @@ namespace Hybrasyl.Objects
         {
             get
             {
-                if (Level == 99)
-                    return 0;
-                else
-                    return (uint) (Math.Pow(Level, 3) * 250 - Experience);
+                var levelExp = (uint) Math.Pow(Level, 3)*250;
+                if (Level == Constants.MAX_LEVEL || Experience >= levelExp)
+                    return 0; 
+                            
+                return (uint) (Math.Pow(Level, 3) * 250 - Experience);
             }
         }
 
@@ -401,9 +402,15 @@ namespace Hybrasyl.Objects
          */
         public void GiveExperience(uint exp)
         {
-            if (Level == 99 || exp < ExpToLevel)
+            if (Level == Constants.MAX_LEVEL || exp < ExpToLevel)
             {
-                Experience += exp;
+                if (uint.MaxValue - Experience >= exp)
+                    Experience += exp;
+                else
+                {
+                    Experience = uint.MaxValue;
+                    SendSystemMessage("You cannot gain any more experience.");
+                }
             }
             else
             {
@@ -412,7 +419,7 @@ namespace Hybrasyl.Objects
                 var levelsGained = 0;
                 Random random = new Random();
 
-                while (exp > 0)
+                while (exp > 0 && Level < 99)
                 {
                     uint expChunk = Math.Min(exp, ExpToLevel);
 
@@ -514,6 +521,9 @@ namespace Hybrasyl.Objects
                         #endregion
                     }
                 }
+                // If a user has just become level 99, add the remainder exp to their box
+                if (Level == 99)
+                    Experience += exp;
 
                 if (levelsGained > 0)
                 {

--- a/hybrasyl/Utility.cs
+++ b/hybrasyl/Utility.cs
@@ -254,6 +254,7 @@ namespace Hybrasyl
     {
         // Eventually most of these should be moved into a config file. For right now they're here.
 
+        public static int MAX_LEVEL = 99;
         public static Regex PercentageRegex = new Regex(@"(\+|\-){0,1}(\d{0,4})%", RegexOptions.Compiled);
         public const int VIEWPORT_SIZE = 24;
         public const byte MAXIMUM_INVENTORY = 59;

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -1542,7 +1542,7 @@ namespace Hybrasyl
                             user.SendMessage("That's not a valid level, champ.", 0x1);
                         else
                         {
-                            user.Level = newLevel;
+                            user.Level = newLevel > Constants.MAX_LEVEL ? (byte) Constants.MAX_LEVEL : newLevel;
                             user.UpdateAttributes(StatUpdateFlags.Full);
                             user.SendMessage(String.Format("Level changed to {0}", newLevel), 0x1);
                         }

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -1260,7 +1260,15 @@ namespace Hybrasyl
                             }
                         }
                         break;
-
+                    /* Reset a user to level 1, with no level points and no experience. */
+                    case "/expreset":
+                    {
+                        user.LevelPoints = 0;
+                        user.Level = 1;
+                        user.Experience = 0;
+                        user.UpdateAttributes(StatUpdateFlags.Full);
+                    }
+                        break;
                     case "/group":
                         User newMember = FindUser(args[1]);
 
@@ -2022,7 +2030,7 @@ namespace Hybrasyl
                             user.SendMessage("Invalid class. " + errorMessage, 0x1);
 
                         }
-                        else if (!byte.TryParse(args[2], out level) || level < 1 || level > 99)
+                        else if (!byte.TryParse(args[2], out level) || level < 1 || level > Constants.MAX_LEVEL)
                         {
                             user.SendMessage("Invalid level. " + errorMessage, 0x1);
                         }


### PR DESCRIPTION
This PR updates levelling to ensure that experience cannot overflow, that levels should only go upwards, and that you cannot exceed `Constants.MAX_LEVEL` for your level. Your "XP to next level" will correctly display as 0 at `MAX_LEVEL` and experience will be properly added to your box in all cases.

It also adds a slash command `/expreset` for testing.

cc: @norrismiv 
