### PR TITLE
[SERVER-159] Display item quantities in exchange window

### DIFF
--- a/hybrasyl/Enums.cs
+++ b/hybrasyl/Enums.cs
@@ -56,6 +56,16 @@ namespace Hybrasyl
             Red = 248
         }
 
+        internal static class ExchangeActions
+        {
+            public const byte Initiate = 0x00;
+            public const byte QuantityPrompt = 0x01;
+            public const byte ItemUpdate = 0x02;
+            public const byte GoldUpdate = 0x03;
+            public const byte Cancel = 0x04;
+            public const byte Confirm = 0x05;
+        }
+
         //this is a wip
         internal static class OpCodes
         {
@@ -96,7 +106,8 @@ namespace Hybrasyl
             public const byte MapData = 0x3C;
             public const byte UseSkill = 0x3E;
             public const byte Cooldown = 0x3F;
-            public const byte ClickObject = 0x43;
+            public const byte Exchange = 0x42;
+            public const byte ClickObject = 0x43;           
             public const byte CancelCast = 0x48;
             public const byte ServerSelect = 0x57;
             public const byte MapLoadComplete = 0x58;

--- a/hybrasyl/Inventory.cs
+++ b/hybrasyl/Inventory.cs
@@ -152,7 +152,7 @@ namespace Hybrasyl
 
                 if (quantity > theItem.Count)
                 {
-                    giver.SendSystemMessage(String.Format("You don't have that many {0} to give!", theItem.Name));
+                    giver.SendSystemMessage($"You don't have that many {theItem.Name} to give!");
                     return false;
                 }
 
@@ -163,13 +163,13 @@ namespace Hybrasyl
                 {
                     if (giver == _target)
                     {
-                        _target.SendSystemMessage(String.Format("They can't carry any more {0}", theItem.Name));
-                        _source.SendSystemMessage(String.Format("You can't carry any more {0}.", theItem.Name));
+                        _target.SendSystemMessage($"They can't carry any more {theItem.Name}");
+                        _source.SendSystemMessage($"You can't carry any more {theItem.Name}.");
                     }
                     else
                     {
-                        _source.SendSystemMessage(String.Format("They can't carry any more {0}", theItem.Name));
-                        _target.SendSystemMessage(String.Format("You can't carry any more {0}.", theItem.Name));
+                        _source.SendSystemMessage($"They can't carry any more {theItem.Name}");
+                        _target.SendSystemMessage($"You can't carry any more {theItem.Name}.");
                     }
                     return false;
                 }
@@ -356,7 +356,7 @@ namespace Hybrasyl
             var output = new object[inventory.Size];
             for (byte i = 0; i < inventory.Size; i++)
             {
-                var itemInfo = new Dictionary<String, object>();
+                var itemInfo = new Dictionary<string, object>();
                 if (inventory[i] != null)
                 {
                     itemInfo["Name"] = inventory[i].Name;
@@ -580,7 +580,7 @@ namespace Hybrasyl
             }
         }
 
-        public bool TryGetValue(String name, out Item item)
+        public bool TryGetValue(string name, out Item item)
         {
             item = null;
             List<Item> itemList;

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -2146,11 +2146,6 @@ namespace Hybrasyl.Objects
                 RequestorId = requestor.Id,
                 RequestorName = requestor.Name
             }.Packet());
-            var x42 = new ServerPacket(0x42);
-            x42.WriteByte(0); // show exchange window
-            x42.WriteUInt32(requestor.Id);
-            x42.WriteString8(requestor.Name);
-            Enqueue(x42);
         }
 
         /// <summary>

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -2180,7 +2180,10 @@ namespace Hybrasyl.Objects
                 x42.WriteByte(slot); // Which "exchange slot" to update
                 x42.WriteUInt16((ushort)(0x8000 + toAdd.Sprite));
                 x42.WriteByte(toAdd.Color);
-                x42.WriteString8(toAdd.Name);
+                if (toAdd.Stackable && toAdd.Count > 1)
+                    x42.WriteString8($"{toAdd.Name} ({toAdd.Count})");
+                else
+                    x42.WriteString8(toAdd.Name);
                 Enqueue(x42);
             }
         }

--- a/hybrasyl/ServerPacketStructures.cs
+++ b/hybrasyl/ServerPacketStructures.cs
@@ -49,6 +49,73 @@ namespace Hybrasyl
 
         }
 
+        internal partial class Exchange
+        {
+            private static byte OpCode =
+                OpCodes.Exchange;
+
+            internal byte Action;
+            internal uint Gold;
+            internal bool Side;
+            internal string RequestorName;
+            internal uint RequestorId;
+            internal byte ItemSlot;
+            internal ushort ItemSprite;
+            internal byte ItemColor;
+            internal string ItemName;
+            internal const string CancelMessage = "Exchange was cancelled.";
+            internal const string ConfirmMessage = "You exchanged.";
+
+            internal ServerPacket Packet()
+            {
+                ServerPacket packet = new ServerPacket(OpCode);
+                packet.WriteByte(Action);
+                switch (Action)
+                {
+                    case ExchangeActions.Initiate:
+                    {
+                        packet.WriteUInt32(RequestorId);
+                        packet.WriteString8(RequestorName);
+                    }
+                        break;
+                    case ExchangeActions.QuantityPrompt:
+                    {
+                        packet.WriteByte(ItemSlot);
+                    }
+                        break;
+                    case ExchangeActions.ItemUpdate:
+                    {
+                        packet.WriteByte((byte) (Side ? 0 : 1));
+                        packet.WriteByte(ItemSlot);
+                        packet.WriteUInt16((ushort) (0x8000 + ItemSprite));
+                        packet.WriteByte(ItemColor);
+                        packet.WriteString8(ItemName);
+                    }
+                        break;
+                    case ExchangeActions.GoldUpdate:
+                    {
+                        packet.WriteByte((byte) (Side ? 0 : 1));
+                        packet.WriteUInt32(Gold);
+                    }
+                        break;
+                    case ExchangeActions.Cancel:
+                    {
+                        packet.WriteByte((byte) (Side ? 0 : 1));
+                        packet.WriteString8(CancelMessage);
+
+                    }
+                        break;
+                    case ExchangeActions.Confirm:
+                    {
+                        packet.WriteByte((byte) (Side ? 0 : 1));
+                        packet.WriteString8(ConfirmMessage);
+                    }
+                        break;
+                }
+                return packet;
+            }
+        }
+
         internal partial class PlaySound
         {
             private byte OpCode;


### PR DESCRIPTION
This PR is a very simple fix - exchanges will now display quantity in the exchange window for a stackable item (e.g. `Moldy Newspapers (3)`).
