### PR TITLE
[SERVER-85] Implement use support on items

### DIFF
--- a/hybrasyl/Objects/Item.cs
+++ b/hybrasyl/Objects/Item.cs
@@ -120,6 +120,8 @@ namespace Hybrasyl.Objects
 
         public new ushort Sprite => Template.Properties.Appearance.Sprite;
 
+        public ItemPropertiesUse Use => Template.Properties.Use;
+
         public ushort EquipSprite
         {
             get
@@ -149,6 +151,7 @@ namespace Hybrasyl.Objects
                 return XSD.WeaponType.none;
             }
         }
+
         public byte EquipmentSlot => Convert.ToByte(Template.Properties.Equipment.Slot);
         public int Weight => Template.Properties.Physical.Weight;
         public int MaximumStack => Template.Properties.Stackable.Max;
@@ -229,17 +232,56 @@ namespace Hybrasyl.Objects
 
         public void Invoke(User trigger)
         {
-            /*
-            try
+            // Run through all the different potential uses. We allow combinations of any
+            // use specified in the item XML.
+            Logger.InfoFormat($"User {trigger.Name}: used item {Name}");
+            if (Use.ScriptnameSpecified)
             {
-                World.ScriptMethod(ScriptName, this, trigger);
-            }
-            catch
+                Script invokeScript;
+                if (!World.ScriptProcessor.TryGetScript(Use.Scriptname, out invokeScript))
+                {
+                    trigger.SendSystemMessage("It doesn't work.");
+                    return;
+                }
+                    
+                try
+                {
+                    invokeScript.ExecuteScriptableFunction("OnUse", new HybrasylWorldObject(this), new HybrasylUser(trigger));
+                }
+                catch (Exception e)
+                {
+                    trigger.SendSystemMessage("It doesn't work.");
+                    Logger.ErrorFormat($"User {trigger.Name}, item {Name}: exception {e}");
+                }              
+            }            
+            if (Use.EffectSpecified)
             {
-                trigger.SendMessage("It doesn't work.", 3);
+               trigger.SendEffect(trigger.Id, Use.Effect.Id, Use.Effect.Speed); 
             }
-             * */
-            trigger.SendMessage("Not implemented.", 3);
+            if (Use.PlayerEffectSpecified)
+            {
+                if (Use.PlayerEffect.GoldSpecified)
+                    trigger.AddGold(new Gold((uint)Use.PlayerEffect.Gold));
+                if (Use.PlayerEffect.HpSpecified)
+                    trigger.Heal(Use.PlayerEffect.Hp);
+                if (Use.PlayerEffect.MpSpecified)
+                    trigger.RegenerateMp(Use.PlayerEffect.Mp);
+                if (Use.PlayerEffect.XpSpecified)
+                    trigger.GiveExperience((uint)Use.PlayerEffect.Xp);
+                trigger.UpdateAttributes(StatUpdateFlags.Current|StatUpdateFlags.Experience);
+            }
+            if (Use.SoundSpecified)
+            {
+                trigger.SendSound((byte) Use.Sound.Id);
+            }
+            if (Use.TeleportSpecified)
+            {
+                trigger.Teleport(Use.Teleport.Value, Use.Teleport.X, Use.Teleport.Y);
+            }
+            if (Use.ConsumedSpecified)
+            {
+                Count--;
+            }
         }
 
         public Item(int id, World world)

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -778,7 +778,6 @@ namespace Hybrasyl.Objects
             Enqueue(x04);
         }
 
-
         public void DisplayIncomingWhisper(String charname, String message)
         {
             Client.SendMessage(String.Format("{0}\" {1}", charname, message), 0x0);
@@ -1641,6 +1640,19 @@ namespace Hybrasyl.Objects
             Inventory.Swap(oldSlot, newSlot);
             SendItemUpdate(Inventory[oldSlot], oldSlot);
             SendItemUpdate(Inventory[newSlot], newSlot);
+        }
+
+        public override void RegenerateMp(double mp, Creature regenerator = null)
+        {
+            base.RegenerateMp(mp, regenerator);
+            UpdateAttributes(StatUpdateFlags.Current);
+        }
+
+        public override void Damage(double damage, Enums.Element element = Enums.Element.None,
+            Enums.DamageType damageType = Enums.DamageType.Direct, Creature attacker = null)
+        {
+            base.Damage(damage, element, damageType, attacker);
+            UpdateAttributes(StatUpdateFlags.Current);
         }
 
         public override void Attack(Direction direction, Castable castObject = null, Creature target = null)

--- a/hybrasyl/Objects/WorldObject.cs
+++ b/hybrasyl/Objects/WorldObject.cs
@@ -30,6 +30,8 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using System.Runtime.Remoting.Messaging;
+using Community.CsharpSqlite;
 
 namespace Hybrasyl.Objects
 {
@@ -790,6 +792,31 @@ namespace Hybrasyl.Objects
         //public virtual bool AddEquipment(Item item) { return false; }
         //public virtual bool AddEquipment(Item item, byte slot, bool sendUpdate = true) { return false; }
         //public virtual bool RemoveEquipment(byte slot) { return false; }
+
+        public virtual void Heal(double heal, Creature healer = null)
+        {
+            if (AbsoluteImmortal || PhysicalImmortal)
+                return;
+
+            if (Hp == MaximumHp || heal > MaximumHp)
+                return;
+
+            Hp = heal > uint.MaxValue ? MaximumHp : Math.Min(MaximumHp, (uint)(Hp + heal));
+
+            SendDamageUpdate(this);
+
+        }
+
+        public virtual void RegenerateMp(double mp, Creature regenerator = null)
+        {
+            if (AbsoluteImmortal)
+                return;
+
+            if (Mp == MaximumMp || mp > MaximumMp)
+                return;
+
+            Mp = mp > uint.MaxValue ? MaximumMp : Math.Min(MaximumMp, (uint) (Mp + mp));
+        }
 
         public virtual void Damage(double damage, Enums.Element element = Enums.Element.None, Enums.DamageType damageType = Enums.DamageType.Direct, Creature attacker = null)
         {

--- a/hybrasyl/Scripting.cs
+++ b/hybrasyl/Scripting.cs
@@ -560,7 +560,7 @@ __builtins__.raw_input = None
         internal User User { get; set; }
         internal HybrasylWorld World { get; set; }
         internal HybrasylMap Map { get; set; }
-        public string Name { get { return User.Name; } }
+        public string Name => User.Name;
 
         public HybrasylUser(User user)
         {
@@ -631,15 +631,30 @@ __builtins__.raw_input = None
                 User.Effect(x, y, effect, speed);
         }
 
-        public void Teleport(String location)
+        public void Teleport(String location, int x, int y)
         {
-
-
+            User.Teleport(location, (byte) x, (byte) y);
         }
 
         public void SoundEffect(byte sound)
         {
             User.SendSound(sound);
+        }
+
+        public void HealToFull()
+        {
+            User.Heal(User.MaximumHp);
+        }
+
+        public void Heal(int heal)
+        {
+            User.Heal((double)heal);            
+        }
+
+        public void Damage(int damage, Enums.Element element = Enums.Element.None,
+           Enums.DamageType damageType = Enums.DamageType.Direct)
+        {
+            User.Damage((double) damage, element, damageType);
         }
 
         public bool GiveItem(String name)

--- a/hybrasyl/Utility.cs
+++ b/hybrasyl/Utility.cs
@@ -410,7 +410,7 @@ namespace Hybrasyl
         public static string[] BONUS_ATTRS = { "hp", "mp", "str", "int", "wis", "con", "dex", "hit", 
                                                 "dmg", "ac", "mr", "regen" };
 
-        public static string[] SCRIPT_DIRECTORIES = { "npc", "startup", "item", "reactor" };
+        public static string[] SCRIPT_DIRECTORIES = { "npc", "startup", "item", "reactor", "common"};
         public const int MESSAGE_RETURN_SIZE = 64;
     }
 

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -757,6 +757,8 @@ namespace Hybrasyl
                             Logger.InfoFormat("Loading script {0}\\{1}", dir, scriptname);
                             var script = new Script(file, ScriptProcessor);
                             ScriptProcessor.RegisterScript(script);
+                            if (dir == "common")
+                                script.InstantiateScriptable();
                         }
                     }
                     catch (Exception e)
@@ -1251,6 +1253,16 @@ namespace Hybrasyl
                      * will be distributed across a group if the user is in a group, or
                      * passed directly to them if they're not in a group.
                      */
+                    case "/hp":
+                    {
+                        uint hp = 0;
+                        if (uint.TryParse(args[1], out hp))
+                        {
+                            user.Hp = hp;
+                            user.UpdateAttributes(StatUpdateFlags.Current);
+                        }                           
+                    }
+                        break;
                     case "/exp":
                         {
                             uint amount = 0;
@@ -2242,6 +2254,10 @@ namespace Hybrasyl
             {
                 case Enums.ItemType.CanUse:
                     item.Invoke(user);
+                    if (item.Count == 0)
+                        user.RemoveItem(slot);
+                    else
+                        user.SendItemUpdate(item, slot);
                     break;
                 case Enums.ItemType.CannotUse:
                     user.SendMessage("You can't use that.", 3);


### PR DESCRIPTION
This PR implements use support for items. Items can have the following effects, any of which can be combined (and are specified via the item XML):

* arbitary Python scripts
* animation effects
* sound effects
* simple player effects (+/- hp,mp,xp,gold)
* teleportation

This PR also implements a generic `Heal` function, similar to `Damage`, and provides an override for `User` to properly update the client and/or display healthbars after heal/damage occurs. It also implements a new `HealToFull` script API function, health/damage/teleport API functions for scripts, and a new `common` directory for shared effect scripts (such as "reduce HP to 1" or "heal to full HP", etc).

