### PR TITLE
Adds a missing XML tag into ExampleVillage.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The process for compiling Hybrasyl is detailed below.
    in `My Documents\Hybrasyl`.
 
 Now that your setup is complete, you should be able to use the
-[released version of the launcher](https://www.hybrasyl.com/launcher/Hybrasyl_Launcher_Installer.msi)
+[released version of the launcher](https://www.hybrasyl.com/files/Hybrasyl_Launcher_Installer.msi)
 to connect to it. In case you have trouble with the latest launcher, open
 `Hy-brasyl Launcher.sln` and build the project. Launch the executable and
 select `localhost` from the server selection dropdown. You should now be able

--- a/examples/XML/maps/ExampleVillage.xml
+++ b/examples/XML/maps/ExampleVillage.xml
@@ -11,6 +11,7 @@
     <warp x="32" y="38">
       <maptarget x="10" y="2">Example Inn</maptarget>
     </warp>
+  </warps>
   <npcs>
     <npc x="89" y="49">
       <name>Beggar</name>


### PR DESCRIPTION
The server is crashing without this. Otherwise setup has been a breeze so far.

Update: also corrected the URL to the new launcher in the README. Current one is broken.

I agree to the terms of the Contributor Agreement outlined at https://github.com/hybrasyl/server/blob/master/CONTRIBUTING.md.