### PR TITLE
[SERVER-84] Inadequate stat limits

### DIFF
--- a/hybrasyl/Objects/WorldObject.cs
+++ b/hybrasyl/Objects/WorldObject.cs
@@ -536,6 +536,18 @@ namespace Hybrasyl.Objects
         {
         }
 
+        // Clamp to (inclusive) range between [min, max]. Max is optional, and if its
+        // not present then no upper limit will be enforced.
+        private static long ClampToRange(long start, long min, long? max = null)
+        {
+            if (start < min)
+                return min;
+            else if (max != null && start > max)
+                return max.GetValueOrDefault();
+            else
+                return start;
+        }
+
         public uint MaximumHp
         {
             get
@@ -548,7 +560,7 @@ namespace Hybrasyl.Objects
                 if (value < uint.MinValue)
                     return uint.MinValue;
 
-                return (uint)value;
+                return (uint)ClampToRange(value, 1);
             }
         }
 
@@ -564,7 +576,7 @@ namespace Hybrasyl.Objects
                 if (value < uint.MinValue)
                     return uint.MinValue;
 
-                return (uint)value;
+                return (uint)ClampToRange(value, 1);
             }
         }
 
@@ -580,7 +592,7 @@ namespace Hybrasyl.Objects
                 if (value < byte.MinValue)
                     return byte.MinValue;
 
-                return (byte)value;
+                return (byte)ClampToRange(value, 1, Constants.MAX_STAT);
             }
         }
 
@@ -596,7 +608,7 @@ namespace Hybrasyl.Objects
                 if (value < byte.MinValue)
                     return byte.MinValue;
 
-                return (byte)value;
+                return (byte)ClampToRange(value, 1, Constants.MAX_STAT);
             }
         }
 
@@ -612,7 +624,7 @@ namespace Hybrasyl.Objects
                 if (value < byte.MinValue)
                     return byte.MinValue;
 
-                return (byte)value;
+                return (byte)ClampToRange(value, 1, Constants.MAX_STAT);
             }
         }
 
@@ -628,7 +640,7 @@ namespace Hybrasyl.Objects
                 if (value < byte.MinValue)
                     return byte.MinValue;
 
-                return (byte)value;
+                return (byte)ClampToRange(value, 1, Constants.MAX_STAT);
             }
         }
 
@@ -644,7 +656,7 @@ namespace Hybrasyl.Objects
                 if (value < byte.MinValue)
                     return byte.MinValue;
 
-                return (byte)value;
+                return (byte)ClampToRange(value, 1, Constants.MAX_STAT);
             }
         }
 
@@ -658,7 +670,7 @@ namespace Hybrasyl.Objects
                 if (BonusDmg < byte.MinValue)
                     return byte.MinValue;
 
-                return (byte)BonusDmg;
+                return (byte)ClampToRange(BonusDmg, 0);
             }
         }
 
@@ -672,7 +684,7 @@ namespace Hybrasyl.Objects
                 if (BonusHit < byte.MinValue)
                     return byte.MinValue;
 
-                return (byte)BonusHit;
+                return (byte)ClampToRange(BonusHit, 0);
             }
         }
 
@@ -689,7 +701,7 @@ namespace Hybrasyl.Objects
                 if (value < sbyte.MinValue)
                     return sbyte.MinValue;
 
-                return (sbyte)value;
+                return (sbyte)ClampToRange(value, -90, 100);
             }
         }
 
@@ -703,7 +715,7 @@ namespace Hybrasyl.Objects
                 if (BonusMr < sbyte.MinValue)
                     return sbyte.MinValue;
 
-                return (sbyte)BonusMr;
+                return (sbyte)ClampToRange(BonusMr, 0, 8);
             }
         }
 

--- a/hybrasyl/Objects/WorldObject.cs
+++ b/hybrasyl/Objects/WorldObject.cs
@@ -536,12 +536,12 @@ namespace Hybrasyl.Objects
         {
         }
 
-        // Clamp to (inclusive) range between [min, max]. Max is optional, and if its
+        // Restrict to (inclusive) range between [min, max]. Max is optional, and if its
         // not present then no upper limit will be enforced.
-        private static long ClampToRange(long start, long min, long? max = null)
+        private static long BindToRange(long start, long? min, long? max)
         {
-            if (start < min)
-                return min;
+            if (min != null && start < min)
+                return min.GetValueOrDefault();
             else if (max != null && start > max)
                 return max.GetValueOrDefault();
             else
@@ -560,7 +560,7 @@ namespace Hybrasyl.Objects
                 if (value < uint.MinValue)
                     return uint.MinValue;
 
-                return (uint)ClampToRange(value, 1);
+                return (uint)BindToRange(value, StatLimitConstants.MIN_BASE_HPMP, StatLimitConstants.MAX_BASE_HPMP);
             }
         }
 
@@ -576,7 +576,7 @@ namespace Hybrasyl.Objects
                 if (value < uint.MinValue)
                     return uint.MinValue;
 
-                return (uint)ClampToRange(value, 1);
+                return (uint)BindToRange(value, StatLimitConstants.MIN_BASE_HPMP, StatLimitConstants.MAX_BASE_HPMP);
             }
         }
 
@@ -592,7 +592,7 @@ namespace Hybrasyl.Objects
                 if (value < byte.MinValue)
                     return byte.MinValue;
 
-                return (byte)ClampToRange(value, 1, Constants.MAX_STAT);
+                return (byte)BindToRange(value, StatLimitConstants.MIN_STAT, StatLimitConstants.MAX_STAT);
             }
         }
 
@@ -608,7 +608,7 @@ namespace Hybrasyl.Objects
                 if (value < byte.MinValue)
                     return byte.MinValue;
 
-                return (byte)ClampToRange(value, 1, Constants.MAX_STAT);
+                return (byte)BindToRange(value, StatLimitConstants.MIN_STAT, StatLimitConstants.MAX_STAT);
             }
         }
 
@@ -624,7 +624,7 @@ namespace Hybrasyl.Objects
                 if (value < byte.MinValue)
                     return byte.MinValue;
 
-                return (byte)ClampToRange(value, 1, Constants.MAX_STAT);
+                return (byte)BindToRange(value, StatLimitConstants.MIN_STAT, StatLimitConstants.MAX_STAT);
             }
         }
 
@@ -640,7 +640,7 @@ namespace Hybrasyl.Objects
                 if (value < byte.MinValue)
                     return byte.MinValue;
 
-                return (byte)ClampToRange(value, 1, Constants.MAX_STAT);
+                return (byte)BindToRange(value, StatLimitConstants.MIN_STAT, StatLimitConstants.MAX_STAT);
             }
         }
 
@@ -656,7 +656,7 @@ namespace Hybrasyl.Objects
                 if (value < byte.MinValue)
                     return byte.MinValue;
 
-                return (byte)ClampToRange(value, 1, Constants.MAX_STAT);
+                return (byte)BindToRange(value, StatLimitConstants.MIN_STAT, StatLimitConstants.MAX_STAT);
             }
         }
 
@@ -670,7 +670,7 @@ namespace Hybrasyl.Objects
                 if (BonusDmg < byte.MinValue)
                     return byte.MinValue;
 
-                return (byte)ClampToRange(BonusDmg, 0);
+                return (byte)BindToRange(BonusDmg, StatLimitConstants.MIN_DMG, StatLimitConstants.MAX_DMG);
             }
         }
 
@@ -684,7 +684,7 @@ namespace Hybrasyl.Objects
                 if (BonusHit < byte.MinValue)
                     return byte.MinValue;
 
-                return (byte)ClampToRange(BonusHit, 0);
+                return (byte)BindToRange(BonusHit, StatLimitConstants.MIN_HIT, StatLimitConstants.MAX_HIT);
             }
         }
 
@@ -701,7 +701,7 @@ namespace Hybrasyl.Objects
                 if (value < sbyte.MinValue)
                     return sbyte.MinValue;
 
-                return (sbyte)ClampToRange(value, -90, 100);
+                return (sbyte)BindToRange(value, StatLimitConstants.MIN_AC, StatLimitConstants.MAX_AC);
             }
         }
 
@@ -715,7 +715,7 @@ namespace Hybrasyl.Objects
                 if (BonusMr < sbyte.MinValue)
                     return sbyte.MinValue;
 
-                return (sbyte)ClampToRange(BonusMr, 0, 8);
+                return (sbyte)BindToRange(BonusMr, StatLimitConstants.MIN_MR, StatLimitConstants.MAX_MR);
             }
         }
 

--- a/hybrasyl/Utility.cs
+++ b/hybrasyl/Utility.cs
@@ -255,7 +255,6 @@ namespace Hybrasyl
         // Eventually most of these should be moved into a config file. For right now they're here.
 
         public static int MAX_LEVEL = 99;
-        public static int MAX_STAT = 255;
         public static Regex PercentageRegex = new Regex(@"(\+|\-){0,1}(\d{0,4})%", RegexOptions.Compiled);
         public const int VIEWPORT_SIZE = 24;
         public const byte MAXIMUM_INVENTORY = 59;
@@ -422,6 +421,23 @@ namespace Hybrasyl
         public const int CIRCLE_2 = 41;
         public const int CIRCLE_3 = 71;
         public const int CIRCLE_4 = 90;
+    }
+
+    static class StatLimitConstants
+    {
+        public static int MIN_STAT = 1; // str, int, wis, con, dex
+        public static int MAX_STAT = 255;
+        public static int MIN_BASE_HPMP = 1;
+        public static int? MAX_BASE_HPMP = null;
+
+        public static int MIN_DMG = 0;
+        public static int? MAX_DMG = null;
+        public static int MIN_HIT = 0;
+        public static int? MAX_HIT = null;
+        public static int MIN_AC = -90;
+        public static int MAX_AC = 100;
+        public static int MIN_MR = 0;
+        public static int MAX_MR = 8;
     }
 
     static class StatGainConstants

--- a/hybrasyl/Utility.cs
+++ b/hybrasyl/Utility.cs
@@ -255,6 +255,7 @@ namespace Hybrasyl
         // Eventually most of these should be moved into a config file. For right now they're here.
 
         public static int MAX_LEVEL = 99;
+        public static int MAX_STAT = 255;
         public static Regex PercentageRegex = new Regex(@"(\+|\-){0,1}(\d{0,4})%", RegexOptions.Compiled);
         public const int VIEWPORT_SIZE = 24;
         public const byte MAXIMUM_INVENTORY = 59;


### PR DESCRIPTION
Clamps the upper and lower bounds for a bunch of different `Creature` stats. The bounds currently in place are specified here: https://hybrasyl.atlassian.net/browse/SERVER-84.

| Stat | Min | Max |
| ----- | ----- | ----- |
| STR | 1 | 255 |
| INT | 1 | 255 |
| WIS | 1 | 255 |
| CON | 1 | 255 |
| DEX | 1 | 255 |
| HIT | 0 | n/a |
| DAM | 0 | n/a |
| MR | 0 | 8 |
| AC | -90 | 100 |
| HP | 1 | n/a |
| MP | 1 | n/a |

True (unclamped) values are still being preserved in the Creature object so adding and removing inventory items *should* work (and does in the testing I did locally). Any suggestions?

Note that this doesn't fix the lower limit for experience mentioned in the bug report; there's no auto prop for experience so I'm gonna have to test that a bit more thoroughly. Can follow up with that if this looks good.

cc: @baughj @norrismiv 