### PR TITLE
Condition 'last login' message on whether they've logged in before

### DIFF
--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -2189,7 +2189,11 @@ namespace Hybrasyl
             ActiveUsersByName[loginUser.Name] = connectionId;
             Logger.InfoFormat("cid {0}: {1} entering world", connectionId, loginUser.Name);
             Logger.InfoFormat($"{loginUser.SinceLastLoginString}");
-            loginUser.SendSystemMessage($"It has been {loginUser.SinceLastLoginString} since your last login.");
+            // If the user's never logged off before (new character), don't display this message.
+            if (loginUser.Login.LastLogoff != default(DateTime))
+            {
+                loginUser.SendSystemMessage($"It has been {loginUser.SinceLastLoginString} since your last login.");
+            }
             loginUser.SendSystemMessage(HybrasylTime.Now().ToString());
             loginUser.Reindex();
         }


### PR DESCRIPTION
Doesn't display this message if the user has never logged off, i.e. if they're a first-time user. Fixes #49.

Note that USDA still does display the message "0 hours and 0 minutes have passed since you last logged in", but I'd argue its better to just not say anything. Their message doesn't make much sense.