### PR TITLE
SERVER-146 OnDeath event when reaching 0 HP

### DIFF
--- a/hybrasyl/Objects/Item.cs
+++ b/hybrasyl/Objects/Item.cs
@@ -235,10 +235,10 @@ namespace Hybrasyl.Objects
             // Run through all the different potential uses. We allow combinations of any
             // use specified in the item XML.
             Logger.InfoFormat($"User {trigger.Name}: used item {Name}");
-            if (Use.ScriptnameSpecified)
+            if (Use.ScriptSpecified)
             {
                 Script invokeScript;
-                if (!World.ScriptProcessor.TryGetScript(Use.Scriptname, out invokeScript))
+                if (!World.ScriptProcessor.TryGetScript(Use.Script, out invokeScript))
                 {
                     trigger.SendSystemMessage("It doesn't work.");
                     return;

--- a/hybrasyl/Objects/WorldObject.cs
+++ b/hybrasyl/Objects/WorldObject.cs
@@ -877,6 +877,35 @@ namespace Hybrasyl.Objects
             Hp -= normalized;
 
             SendDamageUpdate(this);
+
+            if (Hp == 0)
+            {
+                OnDeath(attacker);
+            }
+        }
+
+        private void OnDeath(Creature attacker)
+        {
+            // give exp
+            if (this is Monster && attacker is User)
+            {
+                var attackerUser = (attacker as User);
+                attackerUser.GiveExperience(this.Experience);
+            }
+
+            //drop items
+            var items = Inventory.ToList();
+            for (byte i = 0; i < Inventory.Size; i++)
+            {
+                byte slot = (byte)(i + 1);
+                Inventory.Remove(slot);
+            }
+            foreach (var item in items)
+            {
+                Map.AddItem(X, Y, item);
+            }
+
+            Remove();
         }
 
         private void SendDamageUpdate(Creature creature)

--- a/hybrasyl/Objects/WorldObject.cs
+++ b/hybrasyl/Objects/WorldObject.cs
@@ -893,17 +893,18 @@ namespace Hybrasyl.Objects
                 attackerUser.GiveExperience(this.Experience);
             }
 
-            //drop items
-            var items = Inventory.ToList();
-            for (byte i = 0; i < Inventory.Size; i++)
-            {
-                byte slot = (byte)(i + 1);
-                Inventory.Remove(slot);
-            }
-            foreach (var item in items)
-            {
-                Map.AddItem(X, Y, item);
-            }
+            // TODO: drop items
+
+            //var items = Inventory.ToList();
+            //for (byte i = 0; i < Inventory.Size; i++)
+            //{
+            //    byte slot = (byte)(i + 1);
+            //    Inventory.Remove(slot);
+            //}
+            //foreach (var item in items)
+            //{
+            //    Map.AddItem(X, Y, item);
+            //}
 
             Remove();
         }

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -405,11 +405,11 @@ namespace Hybrasyl
 
 
             // Load worldmaps
-            foreach (var xml in Directory.GetFiles(WorldMapDirectory))
+            foreach (var xmlWorldMap in Directory.GetFiles(WorldMapDirectory))
             {
                 try
                 {
-                    XSD.WorldMap newWorldMap = Serializer.Deserialize(XmlReader.Create(xml), new XSD.WorldMap());
+                    XSD.WorldMap newWorldMap = Serializer.Deserialize(XmlReader.Create(xmlWorldMap), new XSD.WorldMap());
                     var worldmap = new WorldMap(newWorldMap);
                     WorldMaps.Add(worldmap.Name, worldmap);
                     foreach (var point in worldmap.Points)
@@ -418,35 +418,35 @@ namespace Hybrasyl
                 }
                 catch (Exception e)
                 {
-                    Logger.ErrorFormat("Error parsing {0}: {1}", xml, e);
+                    Logger.ErrorFormat("Error parsing {0}: {1}", xmlWorldMap, e);
                 }
             }
 
             Logger.InfoFormat("World Maps: {0} world maps loaded", WorldMaps.Count);
 
             // Load item variants
-            foreach (var xml in Directory.GetFiles(ItemVariantDirectory))
+            foreach (var xmlItemVariant in Directory.GetFiles(ItemVariantDirectory))
             {
                 try
                 {
-                    VariantGroupType newGroup = Serializer.Deserialize(XmlReader.Create(xml), new VariantGroupType());
+                    VariantGroupType newGroup = Serializer.Deserialize(XmlReader.Create(xmlItemVariant), new VariantGroupType());
                     Logger.DebugFormat("Item variants: loaded {0}", newGroup.Name);
                     ItemVariants.Add(newGroup.Name, newGroup);
                 }
                 catch (Exception e)
                 {
-                    Logger.ErrorFormat("Error parsing {0}: {1}", xml, e);
+                    Logger.ErrorFormat("Error parsing {0}: {1}", xmlItemVariant, e);
                 }
             }
 
             Logger.InfoFormat("Item variants: {0} variant sets loaded", ItemVariants.Count);
 
             // Load items
-            foreach (var xml in Directory.GetFiles(ItemDirectory))
+            foreach (var xmlItem in Directory.GetFiles(ItemDirectory))
             {
                 try
                 {
-                    XSD.ItemType newItem = Serializer.Deserialize(XmlReader.Create(xml), new XSD.ItemType());
+                    XSD.ItemType newItem = Serializer.Deserialize(XmlReader.Create(xmlItem), new XSD.ItemType());
                     Logger.DebugFormat("Items: loaded {0}, id {1}", newItem.Name, newItem.Id);
                     Items.Add(newItem.Id, newItem);
                     ItemCatalog.Add(new Tuple<Sex, string>(Sex.Neutral, newItem.Name), newItem);
@@ -464,29 +464,32 @@ namespace Hybrasyl
                 }
                 catch (Exception e)
                 {
-                    Logger.ErrorFormat("Error parsing {0}: {1}", xml, e);
+                    Logger.ErrorFormat("Error parsing {0}: {1}", xmlItem, e);
                 }
             }
 
-            foreach (var xml in Directory.GetFiles(CastableDirectory))
+            foreach (var xmlCastable in Directory.GetFiles(CastableDirectory, "*.xml"))
             {
                 try
                 {
                     string name = string.Empty;
-                    XSD.Castable newCastable = Serializer.Deserialize(XmlReader.Create(xml), new XSD.Castable());
-                    if (newCastable.Book == XSD.Book.primaryskill || newCastable.Book == XSD.Book.secondaryskill ||
+                    XSD.Castable newCastable = Serializer.Deserialize(XmlReader.Create(xmlCastable), new XSD.Castable());
+                    if (newCastable.Book == XSD.Book.primaryskill || 
+                        newCastable.Book == XSD.Book.secondaryskill ||
                         newCastable.Book == XSD.Book.utilityskill)
                     {
                         Skills.Add(newCastable.Id, newCastable);
                     }
                     else
+                    {
                         Spells.Add(newCastable.Id, newCastable);
+                    }
 
                     Logger.DebugFormat("Castables: loaded {0}, id {1}", newCastable.Name, newCastable.Id);
                 }
                 catch (Exception e)
                 {
-                    Logger.ErrorFormat("Error parsing {0}: {1}", xml, e);
+                    Logger.ErrorFormat("Error parsing {0}: {1}", xmlCastable, e);
                 }
             }
 
@@ -1765,11 +1768,20 @@ namespace Hybrasyl
 
                             creatureName = string.Join(" ", args, 1, args.Length - 1);
 
+                            ushort mapId = user.Map.Id;
+                            byte x = user.X;
+                            byte y = user.Y;
+
+                            if (user.Direction == Direction.North) y -= 1;
+                            else if (user.Direction == Direction.South) y += 1;
+                            else if (user.Direction == Direction.West) x -= 1;
+                            else if (user.Direction == Direction.East) x += 1;
+
                             Creature creature = new Creature()
                             {
                                 Sprite = 1,
                                 World = Game.World,
-                                Map = Game.World.Maps[500],
+                                Map = Game.World.Maps[mapId],
                                 Level = 1,
                                 DisplayText = "TestMob",
                                 BaseHp = 100,
@@ -1782,10 +1794,10 @@ namespace Hybrasyl
                                 BaseDex = 3,
                                 BaseInt = 3,
                                 BaseWis = 3,
-                                X = 50,
-                                Y = 51
+                                X = x,
+                                Y = y
                             };
-                            Game.World.Maps[500].InsertCreature(creature);
+                            Game.World.Maps[mapId].InsertCreature(creature);
                             user.SendVisibleCreature(creature);
                         }
                         break;


### PR DESCRIPTION
An OnDeath event now occurs when a creature receives damage and reaches 0 HP.  The Creature is removed from the Map and, if was a Monster and its attacker was a User, the Monster's experience is given to the User.