### PR TITLE
[server-167] Add status support

### DIFF
--- a/hybrasyl/Book.cs
+++ b/hybrasyl/Book.cs
@@ -1,5 +1,6 @@
 using Hybrasyl.Castables;
 using log4net;
+using Hybrasyl.Castables;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;

--- a/hybrasyl/Enums.cs
+++ b/hybrasyl/Enums.cs
@@ -25,7 +25,8 @@ using System;
 namespace Hybrasyl
 {
     namespace Enums
-    {
+    { 
+
         public enum LegendIcon
         {
             Community = 0,
@@ -101,7 +102,7 @@ namespace Hybrasyl
             public const byte AddEquipment = 0x37;
             public const byte RemoveEquipment = 0x38;
             public const byte SelfProfile = 0x39;
-            public const byte BuffBar = 0x3A;
+            public const byte StatusBar = 0x3A;
             public const byte PingA = 0x3B;
             public const byte MapData = 0x3C;
             public const byte UseSkill = 0x3E;
@@ -259,8 +260,18 @@ namespace Hybrasyl
             Claw
         }
 
+        public enum StatusBarColor
+        {
+            Off,
+            Blue,
+            Green,
+            Orange,
+            Red,
+            White
+        }
+
         [Flags]
-        public enum PlayerStatus : byte
+        public enum PlayerCondition : byte
         {
             Alive = 0x01,
             Frozen = 0x02,

--- a/hybrasyl/Enums.cs
+++ b/hybrasyl/Enums.cs
@@ -25,7 +25,32 @@ using System;
 namespace Hybrasyl
 {
     namespace Enums
-    { 
+    {
+
+        #region Colors and display enumerations
+        public enum LanternSize : byte
+        {
+            None = 0x00,
+            Small = 0x01,
+            Large = 0x02
+        }
+
+        public enum RestPosition : byte
+        {
+            // Seriously, you try naming these
+            Standing = 0x00,
+            RestPosition1 = 0x01,
+            RestPosition2 = 0x02,
+            MaximumChill = 0x03
+        }   
+
+        public enum NameDisplayStyle : byte
+        {
+            GreyHover = 0x00,
+            RedAlwaysOn = 0x01,
+            GreenHover = 0x02,
+            GreyAlwaysOn = 0x03
+        }
 
         public enum LegendIcon
         {
@@ -57,6 +82,51 @@ namespace Hybrasyl
             Red = 248
         }
 
+        public enum TextColor : int
+        {
+            Red = 62,
+            Yellow = 63,
+            DarkBlue = 66,
+            DarkGrey = 67,
+            MediumGrey = 68,
+            LightGrey = 69,
+            DarkPurple = 70,
+            BrightGreen = 71,
+            DarkGreen = 72,
+            Orange = 73,
+            DarkOrange = 74,
+            White = 75,
+            Blue = 76,
+            WhisperBlue = 76,
+            Pink = 77
+        }
+
+        public enum SkinColor : int
+        {
+            Flesh = 0,
+            White = 1,
+            Cocoa = 2,
+            Green = 3,
+            Yellow = 4,
+            Tan = 5,
+            Grey = 6,
+            LightBlue = 7,
+            Orange = 8,
+            Purple = 9
+        }
+        public enum StatusBarColor
+        {
+            Off,
+            Blue,
+            Green,
+            Orange,
+            Red,
+            White
+        }
+
+        #endregion
+
+        #region Opcode enumerations
         internal static class ExchangeActions
         {
             public const byte Initiate = 0x00;
@@ -119,7 +189,9 @@ namespace Hybrasyl
             public const byte MetaData = 0x6F;
 
         }
+        #endregion
 
+        #region Messaging types
         public enum PrivateMessageType : int
         {
             Whisper = 0,
@@ -138,6 +210,8 @@ namespace Hybrasyl
             Spell = 2
         }
 
+        #endregion
+
         public enum UserStatus : byte
         {
             Awake = 0,
@@ -150,45 +224,45 @@ namespace Hybrasyl
             NeedHelp = 7
         }
 
-        public enum TextColor : int
+        #region Slots, element types, item types
+
+        public enum Element : int
         {
-            Red = 62,
-            Yellow = 63,
-            DarkBlue = 66,
-            DarkGrey = 67,
-            MediumGrey = 68,
-            LightGrey = 69,
-            DarkPurple = 70,
-            BrightGreen = 71,
-            DarkGreen = 72,
-            Orange = 73,
-            DarkOrange = 74,
-            White = 75,
-            Blue = 76,
-            WhisperBlue = 76,
-            Pink = 77
+            None = 0x00,
+            Fire = 0x01,
+            Water = 0x02,
+            Wind = 0x03,
+            Earth = 0x04,
+            Light = 0x05,
+            Dark = 0x06,
+            Wood = 0x07,
+            Metal = 0x08,
+            Undead = 0x09,
+            Random = 0x10
         }
 
-        public enum NameStyle : int
+        public enum ItemSlots : int
         {
-            Normal = 0,
-            RedAlwaysOn = 1,
-            GreenHover = 2,
-            GreyAlwaysOn = 3
-        }
-
-        public enum SkinColor : int
-        {
-            Flesh = 0,
-            White = 1,
-            Cocoa = 2,
-            Green = 3,
-            Yellow = 4,
-            Tan = 5,
-            Grey = 6,
-            LightBlue = 7,
-            Orange = 8,
-            Purple = 9
+            None = 0,
+            Weapon = 1,
+            Armor = 2,
+            Shield = 3,
+            Helmet = 4,
+            Earring = 5,
+            Necklace = 6,
+            LHand = 7,
+            RHand = 8,
+            LArm = 9,
+            RArm = 10,
+            Waist = 11,
+            Leg = 12,
+            Foot = 13,
+            // The rest are all "vanity" slots
+            FirstAcc = 14,
+            Trousers = 15,
+            Coat = 16,
+            SecondAcc = 17,
+            ThirdAcc = 18
         }
 
         public static class ServerItemSlots
@@ -260,15 +334,7 @@ namespace Hybrasyl
             Claw
         }
 
-        public enum StatusBarColor
-        {
-            Off,
-            Blue,
-            Green,
-            Orange,
-            Red,
-            White
-        }
+        #endregion
 
         [Flags]
         public enum PlayerCondition : byte
@@ -325,44 +391,6 @@ namespace Hybrasyl
             Female = 0x02
         }
 
-        public enum Element : int
-        {
-            None = 0x00,
-            Fire = 0x01,
-            Water = 0x02,
-            Wind = 0x03,
-            Earth = 0x04,
-            Light = 0x05,
-            Dark = 0x06,
-            Wood = 0x07,
-            Metal = 0x08,
-            Undead = 0x09,
-            Random = 0x10
-        }
-
-        public enum ItemSlots : int
-        {
-            None = 0,
-            Weapon = 1,
-            Armor = 2,
-            Shield = 3,
-            Helmet = 4,
-            Earring = 5,
-            Necklace = 6,
-            LHand = 7,
-            RHand = 8,
-            LArm = 9,
-            RArm = 10,
-            Waist = 11,
-            Leg = 12,
-            Foot = 13,
-            // The rest are all "vanity" slots
-            FirstAcc = 14,
-            Trousers = 15,
-            Coat = 16,
-            SecondAcc = 17,
-            ThirdAcc = 18
-        }
 
         public enum DamageType
         {

--- a/hybrasyl/Enums.cs
+++ b/hybrasyl/Enums.cs
@@ -114,14 +114,14 @@ namespace Hybrasyl
             Orange = 8,
             Purple = 9
         }
-        public enum StatusBarColor
+        public enum StatusBarColor : byte
         {
-            Off,
-            Blue,
-            Green,
-            Orange,
-            Red,
-            White
+            Off = 0,
+            Blue = 1,
+            Green = 2,
+            Orange = 3,
+            Red = 4,
+            White = 5
         }
 
         #endregion

--- a/hybrasyl/Hybrasyl.csproj
+++ b/hybrasyl/Hybrasyl.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -136,6 +136,7 @@
     <Compile Include="Book.cs" />
     <Compile Include="Board.cs" />
     <Compile Include="Compression.cs" />
+    <Compile Include="PlayerStatus.cs" />
     <Compile Include="Legend.cs" />
     <Compile Include="Time.cs" />
     <Compile Include="Client.cs" />
@@ -220,7 +221,7 @@
   </Target>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Import Project="packages\Fody.1.29.4\build\dotnet\Fody.targets" Condition="Exists('packages\Fody.1.29.4\build\dotnet\Fody.targets')" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/hybrasyl/Inventory.cs
+++ b/hybrasyl/Inventory.cs
@@ -73,8 +73,8 @@ namespace Hybrasyl
         {
             return source.Map == target.Map && source.IsInViewport(target) &&
                    target.IsInViewport(source) &&
-                   source.Status == PlayerStatus.Alive &&
-                   target.Status == PlayerStatus.Alive && target.Distance(source) <= Constants.EXCHANGE_DISTANCE;
+                   source.Status == Enums.PlayerCondition.Alive &&
+                   target.Status == PlayerCondition.Alive && target.Distance(source) <= Constants.EXCHANGE_DISTANCE;
 
         }
 
@@ -84,8 +84,8 @@ namespace Hybrasyl
             {
                 return _source.Map == _target.Map && _source.IsInViewport(_target) &&
                        _target.IsInViewport(_source) &&
-                       _source.Status.HasFlag(PlayerStatus.InExchange) &&
-                       _target.Status.HasFlag(PlayerStatus.InExchange) &&
+                       _source.Status.HasFlag(PlayerCondition.InExchange) &&
+                       _target.Status.HasFlag(PlayerCondition.InExchange) &&
                        _active;
             }
         }
@@ -261,8 +261,8 @@ namespace Hybrasyl
         {
             Logger.InfoFormat("Starting exchange between {0} and {1}", _source.Name, _target.Name);
             _active = true;
-            _source.Status |= PlayerStatus.InExchange;
-            _target.Status |= PlayerStatus.InExchange;
+            _source.Status |= PlayerCondition.InExchange;
+            _target.Status |= PlayerCondition.InExchange;
             _source.ActiveExchange = this;
             _target.ActiveExchange = this;
             // Send "open window" packet to both clients
@@ -291,8 +291,8 @@ namespace Hybrasyl
             _target.SendExchangeCancellation(requestor == _target);
             _source.ActiveExchange = null;
             _target.ActiveExchange = null;
-            _source.Status &= ~PlayerStatus.InExchange;
-            _target.Status &= ~PlayerStatus.InExchange;
+            _source.Status &= ~PlayerCondition.InExchange;
+            _target.Status &= ~PlayerCondition.InExchange;
             return true;
         }
 
@@ -316,8 +316,8 @@ namespace Hybrasyl
 
             _source.ActiveExchange = null;
             _target.ActiveExchange = null;
-            _source.Status &= ~PlayerStatus.InExchange;
-            _target.Status &= ~PlayerStatus.InExchange;
+            _source.Status &= ~PlayerCondition.InExchange;
+            _target.Status &= ~PlayerCondition.InExchange;
         }
 
         /// <summary>

--- a/hybrasyl/Inventory.cs
+++ b/hybrasyl/Inventory.cs
@@ -531,9 +531,9 @@ namespace Hybrasyl
         public void RecalculateWeight()
         {
             Weight = 0;
-            foreach (var item in this)
+            foreach (var obj in this)
             {
-                Weight += item.Weight;
+                Weight += obj.Weight;
             }
         }
         public ItemObject this[byte slot]
@@ -583,8 +583,8 @@ namespace Hybrasyl
 
         public bool TryGetValue(string name, out ItemObject itemObject)
         {
-            item = null;
-            List<Item> itemList;
+            itemObject = null;
+            List<ItemObject> itemList;
             Items.Item theItem;
             if (!Game.World.TryGetItemTemplate(name, out theItem) ||
                 !_inventoryIndex.TryGetValue(theItem.Id, out itemList)) return false;

--- a/hybrasyl/Inventory.cs
+++ b/hybrasyl/Inventory.cs
@@ -376,7 +376,7 @@ namespace Hybrasyl
 
             for (byte i = 0; i < jArray.Count; i++)
             {
-                Items.Item itmType = null;
+                Item itmType = null;
                 Dictionary<string, object> item;
                 if (TryGetValue(jArray[i], out item))
                 {                   
@@ -585,7 +585,7 @@ namespace Hybrasyl
         {
             itemObject = null;
             List<ItemObject> itemList;
-            Items.Item theItem;
+            Item theItem;
             if (!Game.World.TryGetItemTemplate(name, out theItem) ||
                 !_inventoryIndex.TryGetValue(theItem.Id, out itemList)) return false;
             itemObject = itemList.First();
@@ -616,7 +616,7 @@ namespace Hybrasyl
 
         public bool Contains(string name)
         {
-            Items.Item theItem;
+            Item theItem;
             return Game.World.TryGetItemTemplate(name, out theItem) && _inventoryIndex.ContainsKey(theItem.Id);
         }
 
@@ -669,7 +669,7 @@ namespace Hybrasyl
 
         public ItemObject Find(string name)
         {
-            Items.Item theItem;
+            Item theItem;
             return Game.World.TryGetItemTemplate(name, out theItem) && _inventoryIndex.ContainsKey(theItem.Id)
                 ? _inventoryIndex[theItem.Id].First()
                 : null;

--- a/hybrasyl/Inventory.cs
+++ b/hybrasyl/Inventory.cs
@@ -376,7 +376,7 @@ namespace Hybrasyl
 
             for (byte i = 0; i < jArray.Count; i++)
             {
-                Item itmType = null;
+                Items.Item itmType = null;
                 Dictionary<string, object> item;
                 if (TryGetValue(jArray[i], out item))
                 {                   
@@ -583,9 +583,9 @@ namespace Hybrasyl
 
         public bool TryGetValue(string name, out ItemObject itemObject)
         {
-            itemObject = null;
-            List<ItemObject> itemList;
-            Item theItem;
+            item = null;
+            List<Item> itemList;
+            Items.Item theItem;
             if (!Game.World.TryGetItemTemplate(name, out theItem) ||
                 !_inventoryIndex.TryGetValue(theItem.Id, out itemList)) return false;
             itemObject = itemList.First();
@@ -616,7 +616,7 @@ namespace Hybrasyl
 
         public bool Contains(string name)
         {
-            Item theItem;
+            Items.Item theItem;
             return Game.World.TryGetItemTemplate(name, out theItem) && _inventoryIndex.ContainsKey(theItem.Id);
         }
 
@@ -669,7 +669,7 @@ namespace Hybrasyl
 
         public ItemObject Find(string name)
         {
-            Item theItem;
+            Items.Item theItem;
             return Game.World.TryGetItemTemplate(name, out theItem) && _inventoryIndex.ContainsKey(theItem.Id)
                 ? _inventoryIndex[theItem.Id].First()
                 : null;

--- a/hybrasyl/Jobs.cs
+++ b/hybrasyl/Jobs.cs
@@ -289,6 +289,28 @@ namespace Hybrasyl
                 }
             }
         }
+
+        public static class StatusTickJob
+        {
+            public static readonly ILog Logger =
+                LogManager.GetLogger(
+                    System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+            public static readonly int Interval = 1;
+
+            public static void Execute(Object obj, ElapsedEventArgs args)
+            {
+                foreach (var connectionId in GlobalConnectionManifest.WorldClients.Keys)
+                {
+                    User user;
+                    if (World.ActiveUsers.TryGetValue(connectionId, out user))
+                    {
+                        World.MessageQueue.Add(new HybrasylControlMessage(ControlOpcodes.StatusTick, user.Name));
+                    }
+                }
+            }
+        }
+
         public static class AutoSnoreJob
         {
             public static readonly ILog Logger =

--- a/hybrasyl/Jobs.cs
+++ b/hybrasyl/Jobs.cs
@@ -300,6 +300,7 @@ namespace Hybrasyl
 
             public static void Execute(Object obj, ElapsedEventArgs args)
             {
+                Logger.Debug("Status tick job starting");
                 foreach (var connectionId in GlobalConnectionManifest.WorldClients.Keys)
                 {
                     User user;
@@ -308,6 +309,8 @@ namespace Hybrasyl
                         World.MessageQueue.Add(new HybrasylControlMessage(ControlOpcodes.StatusTick, user.Name));
                     }
                 }
+                Logger.Debug("Status tick job ending");
+
             }
         }
 

--- a/hybrasyl/Legend.cs
+++ b/hybrasyl/Legend.cs
@@ -116,6 +116,7 @@ namespace Hybrasyl
         public string Text { get; set; }
         public bool Public { get; set; }
         public DateTime Created { get; }
+        public DateTime LastUpdated { get; set; }
         public int Quantity { get; set; }
 
         public LegendMark(LegendIcon icon, LegendColor color, string text, DateTime created,
@@ -128,11 +129,18 @@ namespace Hybrasyl
             Quantity = quantity;
             Prefix = prefix;
             Created = created;
+            LastUpdated = created;
+        }
+
+        public void AddQuantity(int quantity)
+        {
+            Quantity += quantity;
+            LastUpdated = DateTime.Now;
         }
 
         public override string ToString()
         {
-            var aislingDate = HybrasylTime.ConvertToHybrasyl(Created);
+            var aislingDate = HybrasylTime.ConvertToHybrasyl(Created != LastUpdated ? Created : LastUpdated);
             var returnString = Text;
             var markDate = $"{aislingDate.Age} {aislingDate.Year}, {aislingDate.Season}";
 

--- a/hybrasyl/Map.cs
+++ b/hybrasyl/Map.cs
@@ -22,6 +22,7 @@
 
 using C3;
 using Hybrasyl.Objects;
+using Hybrasyl.Maps;
 using Hybrasyl.Properties;
 using Hybrasyl.XML;
 using log4net;
@@ -237,7 +238,7 @@ namespace Hybrasyl
                 warp.MaximumLevel = warpElement.Restrictions.Level.Max;
                 warp.MinimumAbility = warpElement.Restrictions.Ab.Min;
                 warp.MaximumAbility = warpElement.Restrictions.Ab.Max;
-                warp.MobUse = warpElement.Restrictions.NoMobUse == null;
+                warp.MobUse = warpElement.Restrictions.NoMobUse;
                 Warps[new Tuple<byte, byte>(warp.X, warp.Y)] = warp;
             }
 
@@ -275,14 +276,7 @@ namespace Hybrasyl
                     var board = new Objects.Signpost(boardElement.X, boardElement.Y, string.Empty, true, boardElement.Name);
                     InsertSignpost(board);
                     Logger.InfoFormat("{0}: {1} - messageboard loaded", this.Name, board.Name );
-                }
-            
-
-            
-            
-                // TODO: implement spawning
-            
-
+            }
             Load();
         }
 

--- a/hybrasyl/Objects/ItemObject.cs
+++ b/hybrasyl/Objects/ItemObject.cs
@@ -1,4 +1,3 @@
-﻿
 ﻿/*
  * This file is part of Project Hybrasyl.
  *
@@ -23,13 +22,14 @@
 
 using FastMember;
 using Hybrasyl.Enums;
-using Hybrasyl.XSD;
+using Hybrasyl.Items;
 using Hybrasyl.Properties;
 using log4net;
 using System;
 using System.CodeDom;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
 namespace Hybrasyl.Objects
@@ -85,7 +85,7 @@ namespace Hybrasyl.Objects
 
             // Check if user is equipping a shield while holding a two-handed weapon
 
-            if (EquipmentSlot == ClientItemSlots.Shield && userobj.Equipment.Weapon != null && userobj.Equipment.Weapon.WeaponType == XSD.WeaponType.twohand)
+            if (EquipmentSlot == ClientItemSlots.Shield && userobj.Equipment.Weapon != null && userobj.Equipment.Weapon.WeaponType == Items.WeaponType.TwoHand)
             {
                 message = "You can't equip a shield with a two-handed weapon.";
                 return false;
@@ -93,7 +93,7 @@ namespace Hybrasyl.Objects
 
             // Check if user is equipping a two-handed weapon while holding a shield
 
-            if (EquipmentSlot == ClientItemSlots.Weapon && (WeaponType == XSD.WeaponType.twohand || WeaponType == XSD.WeaponType.staff) && userobj.Equipment.Shield != null)
+            if (EquipmentSlot == ClientItemSlots.Weapon && (WeaponType == Items.WeaponType.TwoHand || WeaponType == Items.WeaponType.Staff) && userobj.Equipment.Shield != null)
             {
                 message = "You can't equip a two-handed weapon with a shield.";
                 return false;
@@ -116,7 +116,7 @@ namespace Hybrasyl.Objects
             return true;
         }
 
-        private XSD.ItemType Template => World.Items[TemplateId];
+        private Items.Item Template => World.Items[TemplateId];
 
         public new string Name => Template.Name;
 
@@ -124,40 +124,24 @@ namespace Hybrasyl.Objects
 
         public ItemPropertiesUse Use => Template.Properties.Use;
 
-        public ushort EquipSprite
-        {
-            get
-            {
-                if (Template.Properties.Appearance.Equipsprite == -1)
-                    return Template.Properties.Appearance.Sprite;
-                return Template.Properties.Appearance.Equipsprite;
-            }
-        }
+        public ushort EquipSprite => Template.Properties.Appearance.EquipSprite;
 
         public Enums.ItemType ItemType
         {
             get
             {
-                if (Template.Properties.EquipmentSpecified && Template.Properties.Equipment.SlotSpecified)
+                if (Template.Properties.Equipment != null)
                     return Enums.ItemType.Equipment;
                 return Template.Properties.Use != null ? Enums.ItemType.CanUse : Enums.ItemType.CannotUse;
             }
         }
 
-        public XSD.WeaponType WeaponType
-        {
-            get
-            {
-                if (Template.Properties.Equipment.WeapontypeSpecified)
-                    return Template.Properties.Equipment.Weapontype;
-                return XSD.WeaponType.none;
-            }
-        }
+        public Items.WeaponType WeaponType => Template.Properties.Equipment.WeaponType;
 
         public byte EquipmentSlot => Convert.ToByte(Template.Properties.Equipment.Slot);
         public int Weight => Template.Properties.Physical.Weight;
         public int MaximumStack => Template.Properties.Stackable.Max;
-        public bool Stackable => Template.Properties.StackableSpecified && Template.Properties.Stackable.Max > 1;
+        public bool Stackable => Template.Properties.Stackable != null && Template.Properties.Stackable.Max > 1;
 
         public uint MaximumDurability => Template.Properties.Physical.Durability;
 
@@ -166,65 +150,65 @@ namespace Hybrasyl.Objects
         public Enums.Class Class => (Enums.Class) Template.Properties.Restrictions.@Class;
         public Sex Sex => (Sex)Template.Properties.Restrictions.Gender;
 
-        public int BonusHp => Template.Properties.Stateffects.@Base.Hp;
-        public int BonusMp => Template.Properties.Stateffects.@Base.Mp;
-        public sbyte BonusStr => Template.Properties.Stateffects.@Base.Str;
-        public sbyte BonusInt => Template.Properties.Stateffects.@Base.@Int;
-        public sbyte BonusWis => Template.Properties.Stateffects.@Base.Wis;
-        public sbyte BonusCon => Template.Properties.Stateffects.@Base.Con;
-        public sbyte BonusDex => Template.Properties.Stateffects.@Base.Dex;
-        public sbyte BonusDmg => Template.Properties.Stateffects.Combat.Dmg;
-        public sbyte BonusHit => Template.Properties.Stateffects.Combat.Hit;
-        public sbyte BonusAc => Template.Properties.Stateffects.Combat.Ac;
-        public sbyte BonusMr => Template.Properties.Stateffects.Combat.Mr;
-        public sbyte BonusRegen => Template.Properties.Stateffects.Combat.Regen;
+        public int BonusHp => Template.Properties.StatEffects.@Base.Hp;
+        public int BonusMp => Template.Properties.StatEffects.@Base.Mp;
+        public sbyte BonusStr => Template.Properties.StatEffects.@Base.Str;
+        public sbyte BonusInt => Template.Properties.StatEffects.@Base.@Int;
+        public sbyte BonusWis => Template.Properties.StatEffects.@Base.Wis;
+        public sbyte BonusCon => Template.Properties.StatEffects.@Base.Con;
+        public sbyte BonusDex => Template.Properties.StatEffects.@Base.Dex;
+        public sbyte BonusDmg => Template.Properties.StatEffects.Combat.Dmg;
+        public sbyte BonusHit => Template.Properties.StatEffects.Combat.Hit;
+        public sbyte BonusAc => Template.Properties.StatEffects.Combat.Ac;
+        public sbyte BonusMr => Template.Properties.StatEffects.Combat.Mr;
+        public sbyte BonusRegen => Template.Properties.StatEffects.Combat.Regen;
         public byte Color => Convert.ToByte(Template.Properties.Appearance.Color);
 
-        public byte BodyStyle => Convert.ToByte(Template.Properties.Appearance.Bodystyle);
+        public byte BodyStyle => Convert.ToByte(Template.Properties.Appearance.BodyStyle);
 
         public Enums.Element Element
         {
             get
             {
-                if (WeaponType == XSD.WeaponType.none)
-                    return (Enums.Element) Template.Properties.Stateffects.Element.Defense;
-                return (Enums.Element) Template.Properties.Stateffects.Element.Offense;
+                if (WeaponType == Items.WeaponType.None)
+                    return (Enums.Element) Template.Properties.StatEffects.Element.Defense;
+                return (Enums.Element) Template.Properties.StatEffects.Element.Offense;
             }
         }
         public ushort MinLDamage => Template.Properties.Damage.Large.Min;
         public ushort MaxLDamage => Template.Properties.Damage.Large.Max;
         public ushort MinSDamage => Template.Properties.Damage.Small.Min;
         public ushort MaxSDamage => Template.Properties.Damage.Small.Max;
-        public ushort DisplaySprite => Template.Properties.Appearance.Displaysprite;
+        public ushort DisplaySprite => Template.Properties.Appearance.DisplaySprite;
 
         public uint Value => Template.Properties.Physical.Value;
 
-        public sbyte Regen => Template.Properties.Stateffects.Combat.Regen;
+        public sbyte Regen => Template.Properties.StatEffects.Combat.Regen;
 
-        public bool Enchantable => Template.Properties.Flags.HasFlag(XSD.ItemFlags.enchantable);
+        public bool Enchantable => Template.Properties.Flags.HasFlag(ItemFlags.Enchantable);
 
-        public bool Consecratable => Template.Properties.Flags.HasFlag(XSD.ItemFlags.consecratable);
+        public bool Consecratable => Template.Properties.Flags.HasFlag(ItemFlags.Consecratable);
 
-        public bool Tailorable => Template.Properties.Flags.HasFlag(XSD.ItemFlags.tailorable);
+        public bool Tailorable => Template.Properties.Flags.HasFlag(ItemFlags.Tailorable);
 
-        public bool Smithable => Template.Properties.Flags.HasFlag(XSD.ItemFlags.smithable);
+        public bool Smithable => Template.Properties.Flags.HasFlag(ItemFlags.Smithable);
         public bool Perishable => Template.Properties.Physical.Perishable;
 
-        public bool Exchangeable => Template.Properties.Flags.HasFlag(XSD.ItemFlags.exchangeable);
+        public bool Exchangeable => Template.Properties.Flags.HasFlag(ItemFlags.Exchangeable);
 
-        public bool Master => Template.Properties.Flags.HasFlag(XSD.ItemFlags.master);
+        public bool Master => Template.Properties.Flags.HasFlag(ItemFlags.Master);
 
-        public bool Unique => Template.Properties.Flags.HasFlag(XSD.ItemFlags.unique);
+        public bool Unique => Template.Properties.Flags.HasFlag(ItemFlags.Unique);
 
-        public bool UniqueEquipped => Template.Properties.Flags.HasFlag(XSD.ItemFlags.uniqueequipped);
+        public bool UniqueEquipped => Template.Properties.Flags.HasFlag(ItemFlags.UniqueEquipped);
 
         public bool IsVariant => Template.IsVariant;
 
-        public XSD.ItemType ParentItem => Template.ParentItem;
+        public Items.Item ParentItem => Template.ParentItem;
 
-        public XSD.VariantType CurrentVariant => Template.CurrentVariant;
+        public Items.Variant CurrentVariant => Template.CurrentVariant;
 
-        public XSD.ItemType GetVariant(int variantId)
+        public Items.Item GetVariant(int variantId)
         {
             return Template.Variants[variantId];
         }
@@ -238,10 +222,10 @@ namespace Hybrasyl.Objects
             // Run through all the different potential uses. We allow combinations of any
             // use specified in the item XML.
             Logger.InfoFormat($"User {trigger.Name}: used item {Name}");
-            if (Use.ScriptnameSpecified)
+            if (Use.Script != null)
             {
                 Script invokeScript;
-                if (!World.ScriptProcessor.TryGetScript(Use.Scriptname, out invokeScript))
+                if (!World.ScriptProcessor.TryGetScript(Use.Script, out invokeScript))
                 {
                     trigger.SendSystemMessage("It doesn't work.");
                     return;
@@ -257,31 +241,31 @@ namespace Hybrasyl.Objects
                     Logger.ErrorFormat($"User {trigger.Name}, item {Name}: exception {e}");
                 }              
             }            
-            if (Use.EffectSpecified)
+            if (Use.Effect != null)
             {
                trigger.SendEffect(trigger.Id, Use.Effect.Id, Use.Effect.Speed); 
             }
-            if (Use.PlayerEffectSpecified)
+            if (Use.PlayerEffect != null)
             {
-                if (Use.PlayerEffect.GoldSpecified)
+                if (Use.PlayerEffect.Gold > 0)
                     trigger.AddGold(new Gold((uint)Use.PlayerEffect.Gold));
-                if (Use.PlayerEffect.HpSpecified)
+                if (Use.PlayerEffect.Hp != 0)
                     trigger.Heal(Use.PlayerEffect.Hp);
-                if (Use.PlayerEffect.MpSpecified)
+                if (Use.PlayerEffect.Mp != 0)
                     trigger.RegenerateMp(Use.PlayerEffect.Mp);
-                if (Use.PlayerEffect.XpSpecified)
+                if (Use.PlayerEffect.Xp != 0)
                     trigger.GiveExperience((uint)Use.PlayerEffect.Xp);
                 trigger.UpdateAttributes(StatUpdateFlags.Current|StatUpdateFlags.Experience);
             }
-            if (Use.SoundSpecified)
+            if (Use.Sound != null)
             {
                 trigger.SendSound((byte) Use.Sound.Id);
             }
-            if (Use.TeleportSpecified)
+            if (Use.Teleport != null)
             {
                 trigger.Teleport(Use.Teleport.Value, Use.Teleport.X, Use.Teleport.Y);
             }
-            if (Use.ConsumedSpecified)
+            if (Use.Consumed)
             {
                 Count--;
             }
@@ -322,4 +306,4 @@ namespace Hybrasyl.Objects
     
 
 
->>>>>>> Implement status effects including poison, sleep, coma,:hybrasyl/Objects/Item.cs
+>>>>>>> [server-167] Update branch to be in sync witn new XSD:hybrasyl/Objects/Item.cs

--- a/hybrasyl/Objects/ItemObject.cs
+++ b/hybrasyl/Objects/ItemObject.cs
@@ -296,9 +296,3 @@ namespace Hybrasyl.Objects
         }
     }
 }
-
-
-
-    
-
-

--- a/hybrasyl/Objects/Merchant.cs
+++ b/hybrasyl/Objects/Merchant.cs
@@ -33,14 +33,14 @@ namespace Hybrasyl.Objects
         public bool Ready;
         //public npc Data;
         public MerchantJob Jobs { get; set; }
-        public Dictionary<string, Item> Inventory { get; private set; }
+        public Dictionary<string, Items.Item> Inventory { get; private set; }
 
         public Merchant()
             : base()
         {
             Ready = false;
             //Jobs = (MerchantJob).jobs;
-            Inventory = new Dictionary<string, Item>();
+            Inventory = new Dictionary<string, Items.Item>();
             //foreach (var item in data.inventory)
             //{
             //   Inventory.Add(item.name, item);

--- a/hybrasyl/Objects/Merchant.cs
+++ b/hybrasyl/Objects/Merchant.cs
@@ -33,14 +33,14 @@ namespace Hybrasyl.Objects
         public bool Ready;
         //public npc Data;
         public MerchantJob Jobs { get; set; }
-        public Dictionary<string, Items.Item> Inventory { get; private set; }
+        public Dictionary<string, Item> Inventory { get; private set; }
 
         public Merchant()
             : base()
         {
             Ready = false;
             //Jobs = (MerchantJob).jobs;
-            Inventory = new Dictionary<string, Items.Item>();
+            Inventory = new Dictionary<string, Item>();
             //foreach (var item in data.inventory)
             //{
             //   Inventory.Add(item.name, item);

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -22,6 +22,8 @@
 
 using Hybrasyl.Dialogs;
 using Hybrasyl.Enums;
+using Hybrasyl.Castables;
+using Hybrasyl.Nations;
 using log4net;
 using Newtonsoft.Json;
 using System;
@@ -600,9 +602,9 @@ namespace Hybrasyl.Objects
         {
             // Teleport user to national spawn point
             Status |= PlayerCondition.Alive;
-            if (Nation.Spawnpoints.Count != 0)
+            if (Nation.SpawnPoints.Count != 0)
             { 
-                var spawnpoint = Nation.Spawnpoints.First();
+                var spawnpoint = Nation.SpawnPoints.First();
                 Teleport(spawnpoint.Value, spawnpoint.X, spawnpoint.Y);
             }
             else
@@ -2330,7 +2332,7 @@ namespace Hybrasyl.Objects
                 }
             }
             //animation handled here as to not repeatedly send assails.
-            //this.LastAttack = DateTime.Now;
+            //this.LastAttack = DateTime.Now; 
             var assail = new ServerPacketStructures.PlayerAnimation() {Animation = 1, Speed = 20, UserId = this.Id};
             var sound = new ServerPacketStructures.PlaySound() {Sound = 01};
             Enqueue(assail.Packet());

--- a/hybrasyl/Objects/WorldObject.cs
+++ b/hybrasyl/Objects/WorldObject.cs
@@ -136,11 +136,16 @@ namespace Hybrasyl.Objects
         public String Portrait { get; set; }
         public string DisplayText { get; set; }
 
+        public string DeathPileOwner { get; set; }
+        public List<string> DeathPileAllowedLooters { get; set; }
+        public DateTime? DeathPileTime { get; set; }
 
         public VisibleObject()
-        {
-          
-            DisplayText = String.Empty;
+        {         
+            DisplayText = string.Empty;
+            DeathPileAllowedLooters = new List<string>();
+            DeathPileOwner = string.Empty;
+            DeathPileTime = null;
         }
 
         public virtual void AoiEntry(VisibleObject obj)

--- a/hybrasyl/Objects/WorldObject.cs
+++ b/hybrasyl/Objects/WorldObject.cs
@@ -155,6 +155,8 @@ namespace Hybrasyl.Objects
         {
         }
 
+        public virtual void OnDeath() { }
+
         public Rectangle GetBoundingBox()
         {
             return new Rectangle(X, Y, 1, 1);

--- a/hybrasyl/Objects/WorldObject.cs
+++ b/hybrasyl/Objects/WorldObject.cs
@@ -30,8 +30,6 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using System.Runtime.Remoting.Messaging;
-using Community.CsharpSqlite;
 
 namespace Hybrasyl.Objects
 {

--- a/hybrasyl/Objects/WorldObject.cs
+++ b/hybrasyl/Objects/WorldObject.cs
@@ -866,7 +866,7 @@ namespace Hybrasyl.Objects
                 damage = (damage - reduction) * resist;
             }
 
-            if (attacker == null)
+            if (attacker != null)
                 _mLastHitter = attacker.Id;
 
             var normalized = (uint)damage;

--- a/hybrasyl/Packet.cs
+++ b/hybrasyl/Packet.cs
@@ -378,7 +378,7 @@ namespace Hybrasyl
     };
         #endregion
 
-        public override bool ShouldEncrypt => Opcode != 0x00 && Opcode != 0x10;
+        public override bool ShouldEncrypt => Opcode != 0x00 && Opcode != 0x10 && Opcode != 0x29;
 
         public override bool UseDefaultKey => Opcode == 0x02 || Opcode == 0x03 || Opcode == 0x04 || Opcode == 0x0B || Opcode == 0x26
                                               || Opcode == 0x2D || Opcode == 0x3A || Opcode == 0x42 || Opcode == 0x43 || Opcode == 0x4B

--- a/hybrasyl/PlayerStatus.cs
+++ b/hybrasyl/PlayerStatus.cs
@@ -1,0 +1,217 @@
+﻿
+using System;
+using System.Data.SqlTypes;
+using Community.CsharpSqlite;
+using Hybrasyl.Enums;
+using Hybrasyl.Objects;
+
+namespace Hybrasyl
+{
+    public interface IPlayerStatus
+    {
+
+        string OnTickMessage { get; set; }
+        string OnStartMessage { get; set; }
+        string OnEndMessage { get; set; }
+        string Name { get; }
+        int Duration { get; set; }
+        int Tick { get; set; }
+        DateTime Start { get; }
+        DateTime LastTick { get; }
+        Enums.PlayerCondition Conditions { get; set; }
+        ushort Icon { get; }
+
+        bool Expired { get; }
+
+        double ElapsedSinceTick { get; }
+
+        void OnStart();
+        void OnTick();
+        void OnEnd();
+
+        int GetHashCode();
+    }
+
+    public abstract class PlayerStatus : IPlayerStatus
+    {
+        public string Name { get; }
+        public ushort Icon { get; }
+        public int Tick { get; set; }
+        public int Duration { get; set; }
+        protected User User { get; set; }
+        public Enums.PlayerCondition Conditions { get; set; }
+
+        public DateTime Start { get; }
+
+        public DateTime LastTick { get; private set; }
+
+        public virtual void OnStart()
+        {
+            if (OnStartMessage != string.Empty) User.SendSystemMessage(OnStartMessage);
+        }
+
+        public virtual void OnTick()
+        {
+            LastTick = DateTime.Now;
+            if (OnTickMessage != string.Empty) User.SendSystemMessage(OnTickMessage);
+        }
+
+        public virtual void OnEnd()
+        {
+            if (OnEndMessage != string.Empty) User.SendSystemMessage(OnEndMessage);
+        }
+
+        public bool Expired => (DateTime.Now - Start).TotalSeconds >= Duration;
+
+        public double ElapsedSinceTick => (DateTime.Now - LastTick).TotalSeconds;
+
+        public string OnTickMessage { get; set; }
+        public string OnStartMessage { get; set; }
+        public string OnEndMessage { get; set; }
+
+        protected PlayerStatus(User user, int duration, int tick, ushort icon, string name)
+        {
+            User = user;
+            Duration = duration;
+            Tick = tick;
+            Icon = icon;
+            Name = name;
+            Start = DateTime.Now;
+            OnTickMessage = String.Empty;
+            OnStartMessage = String.Empty;
+            OnEndMessage = String.Empty;
+
+        }
+
+    }
+
+    internal class BlindEffect : PlayerStatus
+    {
+
+        private new const ushort Icon = 3;
+        private new const string Name = "Blind";
+        private new const string OnStartMessage = "You cannot see anything.";
+        private new const string OnEndMessage = "You can see again.";
+
+        public BlindEffect(User user, int duration, int tick) : base(user, duration, tick, Icon, Name)
+        {
+        }
+
+        public override void OnStart()
+        {
+            base.OnStart();
+            User.ToggleBlind();
+        }
+
+        public override void OnTick()
+        {
+        }
+
+        public override void OnEnd()
+        {
+            base.OnEnd();
+            User.ToggleBlind();
+        }
+
+    }
+
+    internal class PoisonEffect : PlayerStatus
+    {
+        private new const ushort Icon = 36;
+        private new const string Name = "Poison";
+        private const ushort OnTickEffect = 25;
+
+        private new const string OnStartMessage = "Poison";
+        private new const string OnTickMessage = "Poison is coursing through your veins.";
+        private new const string OnEndMessage = "You feel better.";
+
+        private readonly double _damagePerTick;
+
+        public PoisonEffect(User user, int duration, int tick, double damagePerTick) : base(user, duration, tick, Icon, Name)
+        {
+            _damagePerTick = damagePerTick;
+        }
+
+        public override void OnStart()
+        {
+            base.OnStart();
+            User.SendEffect(User.Id, OnTickEffect, 120);
+        }
+
+        public override void OnTick()
+        {
+            base.OnTick();
+            User.SendEffect(User.Id, OnTickEffect, 120);
+            User.Damage(_damagePerTick);
+        }
+    }
+
+    internal class ParalyzeEffect : PlayerStatus
+    {
+        private new const ushort Icon = 36;
+        private new const string Name = "Paralyze";
+        private const ushort OnTickEffect = 25;
+
+        private new const string OnStartMessage = "You are in hibernation.";
+        private new const string OnEndMessage = "Your body thaws.";
+
+        public ParalyzeEffect(User user, int duration, int tick) : base(user, duration, tick, Icon, Name)
+        {
+        }
+
+        public override void OnStart()
+        {
+            base.OnStart();
+            User.SendEffect(User.Id, OnTickEffect, 1);
+            User.ToggleParalyzed();
+        }
+        public override void OnEnd()
+        {
+            base.OnEnd();
+            User.ToggleParalyzed();
+        }
+
+    }
+
+    internal class SleepEffect : PlayerStatus
+    {
+        private new const ushort Icon = 36;
+        private new const string Name = "Sleep";
+        private const ushort OnTickEffect = 25;
+
+        private new const string OnStartMessage = "You are asleep.";
+        private new const string OnEndMessage = "You awaken.";
+
+        public SleepEffect(User user, int duration, int tick) : base(user, duration, tick, Icon, Name)
+        {
+        }
+
+        public override void OnStart()
+        {
+            base.OnStart();
+            User.SendEffect(User.Id, OnTickEffect, 1);
+            User.ToggleParalyzed();
+        }
+
+        public override void OnTick()
+        {
+            base.OnTick();
+            User.SendEffect(User.Id, OnTickEffect, 1);
+        }
+
+    }
+
+    /*
+        internal class CastableEffect : PlayerEffect
+        {
+            private Script _script;
+
+            public CastableEffect(User user, Script script, int duration = 30000, int ticks = 1000)
+                : base(user, duration, ticks)
+            {
+                _script = script;
+                Icon = icon;
+            }
+        }
+        */
+}

--- a/hybrasyl/PlayerStatus.cs
+++ b/hybrasyl/PlayerStatus.cs
@@ -13,6 +13,7 @@ namespace Hybrasyl
         string OnTickMessage { get; set; }
         string OnStartMessage { get; set; }
         string OnEndMessage { get; set; }
+        string ActionProhibitedMessage { get; set; }
         string Name { get; }
         int Duration { get; set; }
         int Tick { get; set; }
@@ -68,6 +69,7 @@ namespace Hybrasyl
         public string OnTickMessage { get; set; }
         public string OnStartMessage { get; set; }
         public string OnEndMessage { get; set; }
+        public string ActionProhibitedMessage { get; set; }
 
         protected PlayerStatus(User user, int duration, int tick, ushort icon, string name)
         {
@@ -135,13 +137,13 @@ namespace Hybrasyl
         public override void OnStart()
         {
             base.OnStart();
-            User.SendEffect(User.Id, OnTickEffect, 120);
+            User.Effect(OnTickEffect, 120);
         }
 
         public override void OnTick()
         {
             base.OnTick();
-            User.SendEffect(User.Id, OnTickEffect, 120);
+            User.Effect(OnTickEffect, 120);
             User.Damage(_damagePerTick);
         }
     }
@@ -154,6 +156,7 @@ namespace Hybrasyl
 
         private new const string OnStartMessage = "You are in hibernation.";
         private new const string OnEndMessage = "Your body thaws.";
+        private new const string ActionProhibitedMessage = "You cannot move!";
 
         public ParalyzeEffect(User user, int duration, int tick) : base(user, duration, tick, Icon, Name)
         {
@@ -162,7 +165,7 @@ namespace Hybrasyl
         public override void OnStart()
         {
             base.OnStart();
-            User.SendEffect(User.Id, OnTickEffect, 1);
+            User.Effect(OnTickEffect, 120);
             User.ToggleParalyzed();
         }
         public override void OnEnd()
@@ -181,6 +184,8 @@ namespace Hybrasyl
 
         private new const string OnStartMessage = "You are asleep.";
         private new const string OnEndMessage = "You awaken.";
+        private new const string ActionProhibitedMessage = "You are too sleepy to even raise your hands!";
+
 
         public SleepEffect(User user, int duration, int tick) : base(user, duration, tick, Icon, Name)
         {
@@ -189,16 +194,51 @@ namespace Hybrasyl
         public override void OnStart()
         {
             base.OnStart();
-            User.SendEffect(User.Id, OnTickEffect, 1);
+            User.Effect(OnTickEffect, 120);
             User.ToggleParalyzed();
         }
 
         public override void OnTick()
         {
             base.OnTick();
-            User.SendEffect(User.Id, OnTickEffect, 1);
+            User.Effect(OnTickEffect, 120);
         }
 
+    }
+
+    internal class NearDeathEffect : PlayerStatus
+    {
+        private new const ushort Icon = 24;
+        private new const string Name = "NearDeath";
+        private const ushort OnTickEffect = 24;
+
+        private new const string OnStartMessage = "You are near death.";
+        private new const string OnEndMessage = "You have died!";
+        private new const string ActionProhibitedMessage = "The life is draining from your body.";
+
+        public NearDeathEffect(User user, int duration, int tick) : base(user, duration, tick, Icon, Name)
+        {           
+        }
+
+        public override void OnStart()
+        {
+            base.OnStart();
+            User.Effect(OnTickEffect, 120);
+            User.ToggleNearDeath();
+            User.Group?.SendMessage($"{Name} is close to death!");
+        }
+
+        public override void OnTick()
+        {
+            base.OnTick();
+            User.Effect(OnTickEffect, 120);
+        }
+
+        public override void OnEnd()
+        {
+            base.OnEnd();
+            User.OnDeath();
+        }
     }
 
     /*

--- a/hybrasyl/Scripting.cs
+++ b/hybrasyl/Scripting.cs
@@ -32,6 +32,7 @@ using Microsoft.Scripting.Hosting;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Hybrasyl.Items;
@@ -586,6 +587,27 @@ from System import DateTime
         public List<HybrasylUser> GetViewportPlayers()
         {
             return new List<HybrasylUser>();
+        }
+
+        public void Resurrect()
+        {
+            User.Resurrect();
+        }
+
+        public HybrasylUser GetFacingUser()
+        {
+            var facing = User.GetFacingUser();
+            return facing != null ? new HybrasylUser(facing) : null;
+        }
+
+        public List<HybrasylWorldObject> GetFacingObjects()
+        {
+            return User.GetFacingObjects().Select(item => new HybrasylWorldObject(item)).ToList();
+        }
+
+        public void EndComa()
+        {
+            User.EndComa();
         }
 
         public dynamic GetLegendMark(string prefix)

--- a/hybrasyl/Scripting.cs
+++ b/hybrasyl/Scripting.cs
@@ -729,7 +729,7 @@ from System import DateTime
         public bool GiveItem(string name)
         {
             // Does the item exist?
-            Items.Item theitem;
+            Item theitem;
             if (Game.World.ItemCatalog.TryGetValue(new Tuple<Sex, string>(User.Sex, name), out theitem) ||
                 Game.World.ItemCatalog.TryGetValue(new Tuple<Sex, string>(Sex.Neutral, name), out theitem))
             {

--- a/hybrasyl/Scripting.cs
+++ b/hybrasyl/Scripting.cs
@@ -729,7 +729,7 @@ from System import DateTime
         public bool GiveItem(string name)
         {
             // Does the item exist?
-            Item theitem;
+            Items.Item theitem;
             if (Game.World.ItemCatalog.TryGetValue(new Tuple<Sex, string>(User.Sex, name), out theitem) ||
                 Game.World.ItemCatalog.TryGetValue(new Tuple<Sex, string>(Sex.Neutral, name), out theitem))
             {

--- a/hybrasyl/Server.cs
+++ b/hybrasyl/Server.cs
@@ -255,14 +255,11 @@ namespace Hybrasyl
 
             if (bytesRead > 0)
             {
-                if (this is Login)
-                {
-                    Logger.InfoFormat("Dafuq bro");
-                }
+           
                 var inboundBytes = state.ReceiveBufferTake(bytesRead).ToArray();
                 if (inboundBytes[0] != 0xAA)
                 {
-                    Logger.DebugFormat("cid {0}: client is wat",
+                    Logger.DebugFormat("cid {0}: client is sending corrupt data, potentially",
                         client.ConnectionId);
                     state.ResetReceive();
                 }

--- a/hybrasyl/ServerPacketStructures.cs
+++ b/hybrasyl/ServerPacketStructures.cs
@@ -5,6 +5,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
 using Hybrasyl.Enums;
+using log4net;
 
 namespace Hybrasyl
 {
@@ -18,6 +19,10 @@ namespace Hybrasyl
 
     internal class ServerPacketStructures
     {
+
+        public new static readonly ILog Logger =
+               LogManager.GetLogger(
+               System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         internal partial class UseSkill
         {
             private byte OpCode;
@@ -247,7 +252,7 @@ namespace Hybrasyl
             #region Location information
             internal byte X { get; set; }
             internal byte Y { get; set; }
-            internal byte Direction { get; set; }
+            internal Direction Direction { get; set; }
             internal uint Id { get; set; }
             #endregion
 
@@ -289,11 +294,12 @@ namespace Hybrasyl
             {
                 ServerPacket packet = new ServerPacket(OpCode);
                 packet.WriteUInt16(X);
-                packet.WriteByte(Y);
-                packet.WriteByte(Direction);
+                packet.WriteUInt16(Y);
+                packet.WriteByte((byte)Direction);
                 packet.WriteUInt32(Id);
                 packet.WriteUInt16(Helmet);
-                if (DisplayAsMonster)
+                Logger.InfoFormat($"Sex is {Sex}");
+                if (!DisplayAsMonster)
                 {
                     packet.WriteByte((byte) (((byte) Sex*16) + BodySpriteOffset));
                     packet.WriteUInt16(Armor);
@@ -306,13 +312,13 @@ namespace Hybrasyl
                     packet.WriteByte(FirstAccColor);
                     packet.WriteUInt16(FirstAcc);
                     packet.WriteByte(SecondAccColor);
-                    packet.WriteUInt16(SecondAcc););
+                    packet.WriteUInt16(SecondAcc);
                     packet.WriteByte(ThirdAccColor);
                     packet.WriteUInt16(ThirdAcc);
                     packet.WriteByte((byte)LanternSize);
                     packet.WriteByte((byte)RestPosition);
                     packet.WriteUInt16(Overcoat);
-                    packet.WriteUInt16(OvercoatColor);
+                    packet.WriteByte(OvercoatColor);
                     packet.WriteByte((byte)SkinColor);
                     packet.WriteBoolean(Invisible);
                     packet.WriteByte(FaceShape);
@@ -333,8 +339,6 @@ namespace Hybrasyl
                 packet.WriteByte((byte)NameStyle);
                 packet.WriteString8(Name ?? string.Empty);
                 packet.WriteString8(GroupName ?? string.Empty);
-
-
 
                 return packet;
             }

--- a/hybrasyl/ServerPacketStructures.cs
+++ b/hybrasyl/ServerPacketStructures.cs
@@ -11,6 +11,7 @@ namespace Hybrasyl
 
     internal interface IPacket
     {
+        byte OpCode { get; }
         ServerPacket ToPacket();
     }
     //This is a POC. Nothing to see here folks.
@@ -40,7 +41,7 @@ namespace Hybrasyl
             {
                 ServerPacket packet = new ServerPacket(OpCode);
                 packet.WriteUInt16(Icon);
-                packet.WriteByte((byte)BarColor);
+                packet.WriteByte((byte) BarColor);
                 return packet;
             }
         }
@@ -182,6 +183,7 @@ namespace Hybrasyl
         internal partial class HealthBar
         {
             private byte OpCode;
+
             internal HealthBar()
             {
                 OpCode = OpCodes.HealthBar;
@@ -232,5 +234,113 @@ namespace Hybrasyl
                 return packet;
             }
         }
-}
+
+        internal partial class DisplayUser
+        {
+            private byte OpCode;
+
+            internal DisplayUser()
+            {
+                OpCode = OpCodes.DisplayUser;
+            }
+
+            #region Location information
+            internal byte X { get; set; }
+            internal byte Y { get; set; }
+            internal byte Direction { get; set; }
+            internal uint Id { get; set; }
+            #endregion
+
+            #region Appearance
+            internal string Name { get; set; }
+            internal Sex Sex { get; set; }
+            internal ushort Helmet { get; set; }
+            internal byte BodySpriteOffset { get; set; }
+            internal ushort Armor { get; set; }
+            internal byte Shield { get; set; }
+            internal ushort Weapon { get; set; }
+            internal byte Boots { get; set; }
+            internal byte HairColor { get; set; }
+            internal byte BootsColor { get; set; }
+            internal byte FirstAccColor { get; set; }
+            internal ushort FirstAcc { get; set; }
+            internal byte SecondAccColor { get; set; }
+            internal ushort SecondAcc { get; set; }
+            internal byte ThirdAccColor { get; set; }
+            internal ushort ThirdAcc { get; set; }
+            internal RestPosition RestPosition { get; set; }
+            internal ushort Overcoat { get; set; }
+            internal byte OvercoatColor { get; set; }
+            internal SkinColor SkinColor { get; set; }
+            internal bool Invisible { get; set; }
+            internal byte FaceShape { get; set; }
+            internal LanternSize LanternSize { get; set; }
+            internal NameDisplayStyle NameStyle { get; set; }
+            internal string GroupName { get; set; }
+            internal bool DisplayAsMonster { get; set; }
+            internal ushort MonsterSprite { get; set; }
+            #endregion
+
+            // 0x33 <X> <Y> <Direction> <Player ID> <hat/hairstyle> <Offset for sex/status (includes dead/etc)>
+            // <armor sprite> <boots> <armor sprite> <shield> <weapon> <hair color> <boot color> <acc1 color> <acc1>
+            // <acc2 color> <acc2> <acc3 color> <acc3> <nfi> <nfi> <overcoat> <overcoat color> <skin color> <transparency>
+            // <face> <name style (see Enums.NameDisplayStyles)> <name length> <name> <group name length> <group name> (shows up as hovering clickable bar)
+            internal ServerPacket Packet()
+            {
+                ServerPacket packet = new ServerPacket(OpCode);
+                packet.WriteUInt16(X);
+                packet.WriteByte(Y);
+                packet.WriteByte(Direction);
+                packet.WriteUInt32(Id);
+                packet.WriteUInt16(Helmet);
+                if (DisplayAsMonster)
+                {
+                    packet.WriteByte((byte) (((byte) Sex*16) + BodySpriteOffset));
+                    packet.WriteUInt16(Armor);
+                    packet.WriteByte(Boots);
+                    packet.WriteUInt16(Armor);
+                    packet.WriteByte(Shield);
+                    packet.WriteUInt16(Weapon);
+                    packet.WriteByte(HairColor);
+                    packet.WriteByte(BootsColor);
+                    packet.WriteByte(FirstAccColor);
+                    packet.WriteUInt16(FirstAcc);
+                    packet.WriteByte(SecondAccColor);
+                    packet.WriteUInt16(SecondAcc););
+                    packet.WriteByte(ThirdAccColor);
+                    packet.WriteUInt16(ThirdAcc);
+                    packet.WriteByte((byte)LanternSize);
+                    packet.WriteByte((byte)RestPosition);
+                    packet.WriteUInt16(Overcoat);
+                    packet.WriteUInt16(OvercoatColor);
+                    packet.WriteByte((byte)SkinColor);
+                    packet.WriteBoolean(Invisible);
+                    packet.WriteByte(FaceShape);
+                }
+                else
+                {
+                    packet.WriteUInt16(MonsterSprite);
+                    packet.WriteUInt16(HairColor);
+                    packet.WriteUInt16(BootsColor);
+                    // Unknown
+                    packet.WriteByte(0x00);
+                    packet.WriteByte(0x00);
+                    packet.WriteByte(0x00);
+                    packet.WriteByte(0x00);
+                    packet.WriteByte(0x00);
+                    packet.WriteByte(0x00);
+                }
+                packet.WriteByte((byte)NameStyle);
+                packet.WriteString8(Name ?? string.Empty);
+                packet.WriteString8(GroupName ?? string.Empty);
+
+
+
+                return packet;
+            }
+
+
+        }
+    }
+
 }

--- a/hybrasyl/ServerPacketStructures.cs
+++ b/hybrasyl/ServerPacketStructures.cs
@@ -8,10 +8,64 @@ using Hybrasyl.Enums;
 
 namespace Hybrasyl
 {
+
+    internal interface IPacket
+    {
+        ServerPacket ToPacket();
+    }
     //This is a POC. Nothing to see here folks.
 
     internal class ServerPacketStructures
     {
+        internal partial class UseSkill
+        {
+            private byte OpCode;
+
+            internal UseSkill()
+            {
+                OpCode = OpCodes.UseSkill;
+            }
+
+            internal byte Slot { get; set; }
+        }
+
+        internal partial class StatusBar
+        {
+            private static byte OpCode = OpCodes.StatusBar;
+
+            internal ushort Icon;
+            internal StatusBarColor BarColor;
+
+            internal ServerPacket Packet()
+            {
+                ServerPacket packet = new ServerPacket(OpCode);
+                packet.WriteUInt16(Icon);
+                packet.WriteByte((byte)BarColor);
+                return packet;
+            }
+        }
+
+
+        internal partial class Cooldown
+        {
+            private static byte OpCode = OpCodes.Cooldown;
+
+            internal byte Pane;
+            internal byte Slot;
+            internal uint Length;
+
+            internal ServerPacket Packet()
+            {
+                ServerPacket packet = new ServerPacket(OpCode);
+                packet.WriteByte(Pane);
+                packet.WriteByte(Slot);
+                packet.WriteUInt32(Length);
+
+                return packet;
+            }
+
+        }
+
         internal partial class PlayerAnimation
         {
             private byte OpCode;

--- a/hybrasyl/Time.cs
+++ b/hybrasyl/Time.cs
@@ -269,7 +269,7 @@ namespace Hybrasyl
                 throw new ArgumentException("Date passed occurs before known time", nameof(datetime));
 
             var hybrasylTime = new HybrasylTime();
-            var thisAge = Game.Config.Time.Ages.First(age => age.DateInAge(datetime));
+            var thisAge = Game.Config.Time.Ages.FirstOrDefault(age => age.DateInAge(datetime));
             var timeElapsed = datetime.Ticks - World.StartDate.Ticks;
 
             if (thisAge == null)

--- a/hybrasyl/UserGroup.cs
+++ b/hybrasyl/UserGroup.cs
@@ -32,11 +32,13 @@ namespace Hybrasyl
      * This class defines a group of users. Grouped users can whisper to the full group
      * and will also split experience with nearby group members.
      */
+
     public class UserGroup
     {
         public static readonly ILog Logger =
             LogManager.GetLogger(
-            System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+                System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         // Group-related info
         public List<User> Members { get; private set; }
         public DateTime CreatedOn { get; private set; }
@@ -44,6 +46,7 @@ namespace Hybrasyl
         public uint MaxMembers = 0;
 
         private delegate Dictionary<uint, int> DistributionFunc(User source, int full);
+
         private DistributionFunc ExperienceDistributionFunc;
 
         public UserGroup(User founder)
@@ -97,7 +100,7 @@ namespace Hybrasyl
             Members.Add(user);
             user.Group = this;
             ClassCount[user.Class]++;
-            MaxMembers = (uint)Math.Max(MaxMembers, Members.Count);
+            MaxMembers = (uint) Math.Max(MaxMembers, Members.Count);
 
             // Send a distinct message to the new user.
             user.SendMessage("You've joined a group.", MessageTypes.SYSTEM);
@@ -137,10 +140,10 @@ namespace Hybrasyl
         public bool ContainsAllClasses()
         {
             return (ClassCount[Enums.Class.Monk] > 0 &&
-                ClassCount[Enums.Class.Priest] > 0 &&
-                ClassCount[Enums.Class.Rogue] > 0 &&
-                ClassCount[Enums.Class.Warrior] > 0 &&
-                ClassCount[Enums.Class.Wizard] > 0);
+                    ClassCount[Enums.Class.Priest] > 0 &&
+                    ClassCount[Enums.Class.Rogue] > 0 &&
+                    ClassCount[Enums.Class.Warrior] > 0 &&
+                    ClassCount[Enums.Class.Wizard] > 0);
         }
 
         /**
@@ -148,6 +151,7 @@ namespace Hybrasyl
          * to receive a share. It's not OK to be (a) on a different map or
          * (b) really far away on the same map.
          */
+
         private bool WithinRange(User user, User target)
         {
             if (user.Map.Id == target.Map.Id)
@@ -164,6 +168,7 @@ namespace Hybrasyl
         /**
          * Distribute a pool of experience across members of the group.
          */
+
         public void ShareExperience(User source, int experience)
         {
             Dictionary<uint, int> share = ExperienceDistributionFunc(source, experience);
@@ -171,7 +176,7 @@ namespace Hybrasyl
             for (int i = 0; i < Members.Count; i++)
             {
                 // Note: this will only work for positive numbers at this point.
-                Members[i].GiveExperience((uint)share[Members[i].Id]);
+                Members[i].GiveExperience((uint) share[Members[i].Id]);
             }
         }
 
@@ -186,6 +191,7 @@ namespace Hybrasyl
          * This distribution function gives the full quantity of a resource to each of the
          * group members.
          */
+
         private Dictionary<uint, int> Distribution_Full(User source, int full)
         {
             Dictionary<uint, int> share = new Dictionary<uint, int>();
@@ -202,15 +208,26 @@ namespace Hybrasyl
          * Give the full quantity of a resource to each of the group members, +10% bonus
          * if there's at least one representative from each class.
          */
+
         private Dictionary<uint, int> Distribution_AllClassBonus(User source, int full)
         {
             // Check to see if at least one representative from each class is in the group.
             if (ContainsAllClasses())
             {
-                full = (int)(full * 1.10);
+                full = (int) (full*1.10);
             }
 
             return Distribution_Full(source, full);
+        }
+
+        /// <summary>
+        /// Send a system message as a group message, that the entire group can see.
+        /// </summary>
+        /// <param name="message"></param>
+        public void SendMessage(string message)
+        {
+            foreach (var member in Members)
+                member.SendMessage($"[Notice] {message}", MessageTypes.GROUP);
         }
     }
 }

--- a/hybrasyl/Utility.cs
+++ b/hybrasyl/Utility.cs
@@ -28,6 +28,7 @@ using System.ComponentModel;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
+using Hybrasyl.Enums;
 
 namespace Hybrasyl
 {
@@ -293,7 +294,20 @@ namespace Hybrasyl
         public const int TICK_HEARTBEAT_INTERVAL = 60;
         public const int REAP_HEARTBEAT_INTERVAL = 5;
 
+        // The message a spirit gets when it tries to do things it cannot
 
+        public const string SPIRIT_FORBIDDEN = "Spirits cannot do that.";
+
+        public static Dictionary<PlayerCondition, string> STATUS_RESTRICTION_MESSAGES = new Dictionary
+            <PlayerCondition, string>
+        {
+            {PlayerCondition.InComa, NearDeathStatus.ActionProhibitedMessage},
+            {PlayerCondition.Asleep, SleepStatus.ActionProhibitedMessage},
+            {PlayerCondition.Frozen, FreezeStatus.ActionProhibitedMessage},
+            {PlayerCondition.Paralyzed, ParalyzeStatus.ActionProhibitedMessage},
+            {PlayerCondition.Alive, Constants.SPIRIT_FORBIDDEN}
+
+        };
         // These times control various throttling of packet receipts. 
         // The thresholds are in milliseconds.
         // Generally:

--- a/hybrasyl/Utility.cs
+++ b/hybrasyl/Utility.cs
@@ -241,6 +241,7 @@ namespace Hybrasyl
         public const int RegenUser = 4;
         public const int LogoffUser = 5;
         public const int MailNotifyUser = 6;
+        public const int StatusTick = 7;
     }
 
     static class ServerTypes

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -116,7 +116,7 @@ namespace Hybrasyl
 
         public Dictionary<ushort, Map> Maps { get; set; }
         public Dictionary<string, WorldMap> WorldMaps { get; set; }
-        public static Dictionary<int, Items.Item> Items { get; set; }
+        public static Dictionary<int, Item> Items { get; set; }
         public Dictionary<string, Items.VariantGroup> ItemVariants { get; set; } 
         public Dictionary<int, Castables.Castable> Skills { get; set; }
         public Dictionary<int, Castables.Castable> Spells { get; set; }
@@ -147,7 +147,7 @@ namespace Hybrasyl
         public Dictionary<String, DialogSequence> GlobalSequencesCatalog { get; set; }
         private Dictionary<MerchantMenuItem, MerchantMenuHandler> merchantMenuHandlers;
 
-        public Dictionary<Tuple<Sex, String>, Items.Item> ItemCatalog { get; set; }
+        public Dictionary<Tuple<Sex, String>, Item> ItemCatalog { get; set; }
         public Dictionary<String, Map> MapCatalog { get; set; }
 
         public HybrasylScriptProcessor ScriptProcessor { get; set; }
@@ -206,7 +206,7 @@ namespace Hybrasyl
         {
             Maps = new Dictionary<ushort, Map>();
             WorldMaps = new Dictionary<string, WorldMap>();
-            Items = new Dictionary<int, Items.Item>();
+            Items = new Dictionary<int, Item>();
             Skills = new Dictionary<int, Castables.Castable>();
             Spells = new Dictionary<int, Castables.Castable>();
             Monsters = new Dictionary<int, MonsterTemplate>();
@@ -227,7 +227,7 @@ namespace Hybrasyl
 
 
             GlobalSequencesCatalog = new Dictionary<String, DialogSequence>();
-            ItemCatalog = new Dictionary<Tuple<Sex, String>, Items.Item>();
+            ItemCatalog = new Dictionary<Tuple<Sex, String>, Item>();
             MapCatalog = new Dictionary<String, Map>();
 
             ScriptProcessor = new HybrasylScriptProcessor(this);
@@ -450,7 +450,7 @@ namespace Hybrasyl
             {
                 try
                 {
-                    Items.Item newItem = Serializer.Deserialize(XmlReader.Create(xml), new Items.Item());
+                    Item newItem = Serializer.Deserialize(XmlReader.Create(xml), new Item());
                     Logger.DebugFormat("Items: loaded {0}, id {1}", newItem.Name, newItem.Id);
                     Items.Add(newItem.Id, newItem);
                     ItemCatalog.Add(new Tuple<Sex, string>(Sex.Neutral, newItem.Name), newItem);
@@ -556,7 +556,7 @@ namespace Hybrasyl
         }
 
 
-        public Items.Item ResolveVariant(Items.Item item, Items.Variant variant, string variantGroup)
+        public Item ResolveVariant(Item item, Items.Variant variant, string variantGroup)
         {
             var variantItem = item.Clone();
 
@@ -4069,13 +4069,13 @@ namespace Hybrasyl
             }
         }
 
-        public bool TryGetItemTemplate(string name, Sex itemSex, out Items.Item item)
+        public bool TryGetItemTemplate(string name, Sex itemSex, out Item item)
         {
             var itemKey = new Tuple<Sex, String>(itemSex, name);
             return ItemCatalog.TryGetValue(itemKey, out item);
         }
 
-        public bool TryGetItemTemplate(string name, out Items.Item item)
+        public bool TryGetItemTemplate(string name, out Item item)
         {
             // This is kinda gross
             var neutralKey = new Tuple<Sex, String>(Sex.Neutral, name);

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -44,10 +44,6 @@ using System.Threading;
 using System.Timers;
 using System.Xml;
 using System.Xml.Schema;
-<<<<<<< dd3a672caad037bdf97a0faca036275328ecbfb9
-=======
-using Hybrasyl.Castables;
->>>>>>> [server-167] Update branch to be in sync witn new XSD
 using Hybrasyl.Config;
 using Hybrasyl.Nations;
 using Microsoft.Scripting.Utils;
@@ -2389,7 +2385,7 @@ namespace Hybrasyl
 
             switch (item.ItemObjectType)
             {
-                case Enums.ItemType.CanUse:
+                case Enums.ItemObjectType.CanUse:
                     if (item.Durability == 0)
                     {
                         user.SendSystemMessage("This item is too badly damaged to use.");

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -44,6 +44,10 @@ using System.Threading;
 using System.Timers;
 using System.Xml;
 using System.Xml.Schema;
+<<<<<<< dd3a672caad037bdf97a0faca036275328ecbfb9
+=======
+using Hybrasyl.Castables;
+>>>>>>> [server-167] Update branch to be in sync witn new XSD
 using Hybrasyl.Config;
 using Hybrasyl.Nations;
 using Microsoft.Scripting.Utils;
@@ -116,10 +120,10 @@ namespace Hybrasyl
 
         public Dictionary<ushort, Map> Maps { get; set; }
         public Dictionary<string, WorldMap> WorldMaps { get; set; }
-        public static Dictionary<int, Item> Items { get; set; }
-        public Dictionary<string, VariantGroup> ItemVariants { get; set; } 
-        public Dictionary<int, Castable> Skills { get; set; }
-        public Dictionary<int, Castable> Spells { get; set; }
+        public static Dictionary<int, Items.Item> Items { get; set; }
+        public Dictionary<string, Items.VariantGroup> ItemVariants { get; set; } 
+        public Dictionary<int, Castables.Castable> Skills { get; set; }
+        public Dictionary<int, Castables.Castable> Spells { get; set; }
         public Dictionary<int, MonsterTemplate> Monsters { get; set; }
         public Dictionary<int, MerchantTemplate> Merchants { get; set; }
         public Dictionary<int, ReactorTemplate> Reactors { get; set; }
@@ -147,7 +151,7 @@ namespace Hybrasyl
         public Dictionary<String, DialogSequence> GlobalSequencesCatalog { get; set; }
         private Dictionary<MerchantMenuItem, MerchantMenuHandler> merchantMenuHandlers;
 
-        public Dictionary<Tuple<Sex, String>, Item> ItemCatalog { get; set; }
+        public Dictionary<Tuple<Sex, String>, Items.Item> ItemCatalog { get; set; }
         public Dictionary<String, Map> MapCatalog { get; set; }
 
         public HybrasylScriptProcessor ScriptProcessor { get; set; }
@@ -206,9 +210,9 @@ namespace Hybrasyl
         {
             Maps = new Dictionary<ushort, Map>();
             WorldMaps = new Dictionary<string, WorldMap>();
-            Items = new Dictionary<int, Item>();
-            Skills = new Dictionary<int, Castable>();
-            Spells = new Dictionary<int, Castable>();
+            Items = new Dictionary<int, Items.Item>();
+            Skills = new Dictionary<int, Castables.Castable>();
+            Spells = new Dictionary<int, Castables.Castable>();
             Monsters = new Dictionary<int, MonsterTemplate>();
             Merchants = new Dictionary<int, MerchantTemplate>();
             Methods = new Dictionary<string, MethodInfo>();
@@ -219,15 +223,15 @@ namespace Hybrasyl
             Nations = new Dictionary<string, Nation>();
             Portraits = new Dictionary<string, string>();
             GlobalSequences = new List<DialogSequence>();
-            ItemVariants = new Dictionary<string, VariantGroup>();
+            ItemVariants = new Dictionary<string, Items.VariantGroup>();
             Monoliths = new List<Monolith>();
-	        Mailboxes = new Dictionary<string, Mailbox>();
+            Mailboxes = new Dictionary<string, Mailbox>();
             Messageboards = new Dictionary<string, Board>();
             MessageboardIndex = new Dictionary<int, Board>();
 
 
             GlobalSequencesCatalog = new Dictionary<String, DialogSequence>();
-            ItemCatalog = new Dictionary<Tuple<Sex, String>, Item>();
+            ItemCatalog = new Dictionary<Tuple<Sex, String>, Items.Item>();
             MapCatalog = new Dictionary<String, Map>();
 
             ScriptProcessor = new HybrasylScriptProcessor(this);
@@ -433,8 +437,8 @@ namespace Hybrasyl
             {
                 try
                 {
-                    VariantGroup newGroup = Serializer.Deserialize(XmlReader.Create(xml), new VariantGroup());
-                    Logger.DebugFormat("ItemObject variants: loaded {0}", newGroup.Name);
+                    Items.VariantGroup newGroup = Serializer.Deserialize(XmlReader.Create(xml), new Items.VariantGroup());
+                    Logger.DebugFormat("Item variants: loaded {0}", newGroup.Name);
                     ItemVariants.Add(newGroup.Name, newGroup);
                 }
                 catch (Exception e)
@@ -450,7 +454,7 @@ namespace Hybrasyl
             {
                 try
                 {
-                    Item newItem = Serializer.Deserialize(XmlReader.Create(xml), new Item());
+                    Items.Item newItem = Serializer.Deserialize(XmlReader.Create(xml), new Items.Item());
                     Logger.DebugFormat("Items: loaded {0}, id {1}", newItem.Name, newItem.Id);
                     Items.Add(newItem.Id, newItem);
                     ItemCatalog.Add(new Tuple<Sex, string>(Sex.Neutral, newItem.Name), newItem);
@@ -477,7 +481,7 @@ namespace Hybrasyl
                 try
                 {
                     string name = string.Empty;
-                    Castable newCastable = Serializer.Deserialize(XmlReader.Create(xml), new Castable());
+                    Castables.Castable newCastable = Serializer.Deserialize(XmlReader.Create(xml), new Castables.Castable());
                     if (newCastable.Book == Castables.Book.PrimarySkill || newCastable.Book == Castables.Book.SecondarySkill ||
                         newCastable.Book == Castables.Book.UtilitySkill)
                     {
@@ -556,8 +560,7 @@ namespace Hybrasyl
         }
 
 
-        /* Debug ItemVariants*/
-        public Item ResolveVariant(Item item, Variant variant, string variantGroup)
+        public Items.Item ResolveVariant(Items.Item item, Items.Variant variant, string variantGroup)
         {
             var variantItem = item.Clone();
 
@@ -2280,7 +2283,6 @@ namespace Hybrasyl
             loginUser.SetCitizenship();
            
             Logger.DebugFormat("Elapsed time since login: {0}", loginUser.SinceLastLogin);
-
 
             if (loginUser.Nation.SpawnPoints.Count != 0 &&
                 loginUser.SinceLastLogin > Hybrasyl.Constants.NATION_SPAWN_TIMEOUT)
@@ -4071,13 +4073,13 @@ namespace Hybrasyl
             }
         }
 
-        public bool TryGetItemTemplate(string name, Sex itemSex, out Item item)
+        public bool TryGetItemTemplate(string name, Sex itemSex, out Items.Item item)
         {
             var itemKey = new Tuple<Sex, String>(itemSex, name);
             return ItemCatalog.TryGetValue(itemKey, out item);
         }
 
-        public bool TryGetItemTemplate(string name, out Item item)
+        public bool TryGetItemTemplate(string name, out Items.Item item)
         {
             // This is kinda gross
             var neutralKey = new Tuple<Sex, String>(Sex.Neutral, name);


### PR DESCRIPTION
This PR adds status support: poison, sleep, blind, death, etc. It also adds a number of new enums and support for display packet in the new structure format. Cooldown support and status ticks are also added.