### PR TITLE
[SERVER-226] Can't click Next and go to top level menu

### DIFF
--- a/hybrasyl/Dialogs.cs
+++ b/hybrasyl/Dialogs.cs
@@ -169,9 +169,11 @@ namespace Hybrasyl
 
             public bool HasNextDialog()
             {
-                // Only simple dialogs have next buttons; everything else requires alternate input
+                // Only simple dialogs have next buttons; everything else requires alternate input.
+                // In addition, if we are in the last dialog in a sequence, Next should return to 
+                // the main menu.
                 Logger.DebugFormat("index{0}, count{1}");
-                return (Index + 1 < Sequence.Dialogs.Count() && DialogType == DialogTypes.SIMPLE_DIALOG);
+                return (DialogType == DialogTypes.SIMPLE_DIALOG) && (Index <= Sequence.Dialogs.Count());
             }
 
             public ServerPacket GenerateBasePacket(User invoker, VisibleObject invokee)

--- a/hybrasyl/Dialogs.cs
+++ b/hybrasyl/Dialogs.cs
@@ -41,12 +41,15 @@ namespace Hybrasyl
             public Script Script { get; private set; }
             public WorldObject Associate { get; private set; }
             public string PreDisplayCallback { get; private set; }
+            public bool CloseOnEnd { get; set; }
 
-            public DialogSequence(string sequenceName)
+            public DialogSequence(string sequenceName, bool closeOnEnd = false)
             {
                 Name = sequenceName;
                 Dialogs = new List<Dialog>();
                 Id = null;
+                CloseOnEnd = closeOnEnd;
+
             }
 
             /// <summary>

--- a/hybrasyl/Scripting/HybrasylDialogSequence.cs
+++ b/hybrasyl/Scripting/HybrasylDialogSequence.cs
@@ -28,10 +28,11 @@ namespace Hybrasyl.Scripting
     public class HybrasylDialogSequence
     {
         internal DialogSequence Sequence { get; private set; }
+        
 
-        public HybrasylDialogSequence(string sequenceName)
+        public HybrasylDialogSequence(string sequenceName, bool closeOnEnd = false)
         {
-            Sequence = new DialogSequence(sequenceName);
+            Sequence = new DialogSequence(sequenceName, closeOnEnd);
         }
 
         public void AddDialog(HybrasylDialog scriptDialog)

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -3646,12 +3646,22 @@ namespace Hybrasyl
                 }
 
                 // Did the user click next on the last dialog in a sequence?
-                // If so, show them the main menu
+                // If so, either close the dialog or go to the main menu (main menu by 
+                // default
 
                 if (user.DialogState.ActiveDialogSequence.Dialogs.Count() == pursuitIndex)
                 {
                     user.DialogState.EndDialog();
-                    clickTarget.DisplayPursuits(user);
+                    if (user.DialogState.ActiveDialogSequence.CloseOnEnd)
+                    {
+                        Logger.DebugFormat("Sending close packet");
+                        var p = new ServerPacket(0x30);
+                        p.WriteByte(0x0A);
+                        p.WriteByte(0x00);
+                        user.Enqueue(p);
+                    }
+                    else
+                        clickTarget.DisplayPursuits(user);
                 }
 
                 // Is the active dialog an input or options dialog?

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -3645,6 +3645,15 @@ namespace Hybrasyl
                     }
                 }
 
+                // Did the user click next on the last dialog in a sequence?
+                // If so, show them the main menu
+
+                if (user.DialogState.ActiveDialogSequence.Dialogs.Count() == pursuitIndex)
+                {
+                    user.DialogState.EndDialog();
+                    clickTarget.DisplayPursuits(user);
+                }
+
                 // Is the active dialog an input or options dialog?
 
                 if (user.DialogState.ActiveDialog is OptionsDialog)


### PR DESCRIPTION
## Description
This PR fixes the issue where clicking `next` from a dialog will not advance back to the main menu.

## Related PRs
n/a

## Checklist
- [x] Tested and working locally
- [ ] Reviewed
- [ ] Tested and working on dev server
- [ ] Deployed to staging

## How to QA
Talk to an NPC, open a dialog sequence; click next through it - ensure that at the end of the sequence, hitting next returns to the main menu.

## Impacted Areas in Hybrasyl
Dialogs.
