### PR TITLE
Remove SendLoop once and for all

### DIFF
--- a/hybrasyl/Client.cs
+++ b/hybrasyl/Client.cs
@@ -116,7 +116,7 @@ namespace Hybrasyl
             lock (ReceiveLock)
             {
                 _buffer = new byte[BufferSize];
-                _receiveBuffer = new ConcurrentQueue<ClientPacket>;
+                _receiveBuffer = new ConcurrentQueue<ClientPacket>();
             }
         }
 
@@ -160,8 +160,6 @@ namespace Hybrasyl
                 return false;
             }
         }
-
-        public bool 
 
         public void ReceiveBufferAdd(ClientPacket packet)
         {

--- a/hybrasyl/Client.cs
+++ b/hybrasyl/Client.cs
@@ -20,6 +20,7 @@
  *            Kyle Speck    <kojasou@hybrasyl.com>
  */
 
+using Hybrasyl.Enums;
 using log4net;
 using System;
 using System.Collections.Concurrent;
@@ -37,12 +38,36 @@ namespace Hybrasyl
         private const int BufferSize = 1024;
         private byte[] _buffer = new byte[BufferSize];
         public bool Recieving;
-        private ConcurrentQueue<ServerPacket> _sendBuffer = new ConcurrentQueue<ServerPacket>(); 
+        private ConcurrentQueue<ServerPacket> _sendBuffer = new ConcurrentQueue<ServerPacket>();
+        private ConcurrentQueue<ClientPacket> _receiveBuffer = new ConcurrentQueue<ClientPacket>();
+        public ManualResetEvent SendComplete = new ManualResetEvent(false);
+        public static readonly ILog Logger = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         public bool Connected { get; set; }
 
         public long Id { get; }
 
-        public object Lock = new object();
+        private object _recvlock = new object();
+        public object ReceiveLock
+        {
+            get
+            {
+                System.Diagnostics.StackFrame frame = new System.Diagnostics.StackFrame(1);
+                Logger.Debug($"Receive lock acquired by: {frame.GetMethod().Name} on thread {Thread.CurrentThread.ManagedThreadId}");
+                return _recvlock;
+            }
+        }
+
+        private object _sendlock = new object();
+        public object SendLock
+        {
+            get
+            {
+                System.Diagnostics.StackFrame frame = new System.Diagnostics.StackFrame(1);
+                Logger.Debug($"Send lock acquired by: {frame.GetMethod().Name} on thread {Thread.CurrentThread.ManagedThreadId}");
+                return _sendlock;
+            }
+        }
 
         public Socket WorkSocket { get; }
 
@@ -57,7 +82,7 @@ namespace Hybrasyl
 
         public IEnumerable<byte> ReceiveBufferTake(int range)
         {
-            lock (_buffer)
+            lock (ReceiveLock)
             {
                 return _buffer.Take(range);
             }
@@ -65,12 +90,13 @@ namespace Hybrasyl
 
         public IEnumerable<byte> ReceiveBufferPop(int range)
         {
-            lock (_buffer)
+            lock (ReceiveLock)
             {
                 var ret = _buffer.Take(range);
                 var asList = _buffer.ToList();
                 asList.RemoveRange(0, range);
-                _buffer = asList.ToArray();
+                _buffer = new byte[1024];
+                Array.ConstrainedCopy(asList.ToArray(), 0, _buffer, 0, asList.ToArray().Length);
                 return ret;
             }
         }
@@ -87,9 +113,10 @@ namespace Hybrasyl
 
         public void ResetReceive()
         {
-            lock (_buffer)
+            lock (ReceiveLock)
             {
                 _buffer = new byte[BufferSize];
+                _receiveBuffer = new ConcurrentQueue<ClientPacket>;
             }
         }
 
@@ -102,6 +129,8 @@ namespace Hybrasyl
         {
             try
             {
+                ResetReceive();
+                ResetSend();
                 WorkSocket.Shutdown(SocketShutdown.Both);
                 WorkSocket.Close();
             }
@@ -112,6 +141,38 @@ namespace Hybrasyl
 
             Connected = false;
         }
+
+        public bool TryGetPacket(out ClientPacket packet)
+        {
+            packet = null;
+            lock (ReceiveLock)
+            {
+                if (_buffer.Length != 0 && _buffer[0] == 0xAA && _buffer.Length > 3)
+                {
+                    var packetLength = (_buffer[1] << 8) + _buffer[2] + 3;
+                    // Complete packet, pop it off and return it
+                    if (_buffer.Length >= packetLength)
+                    {
+                        packet = new ClientPacket(ReceiveBufferPop(packetLength).ToArray());
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+
+        public bool 
+
+        public void ReceiveBufferAdd(ClientPacket packet)
+        {
+            _receiveBuffer.Enqueue(packet);
+        }
+
+        public bool ReceiveBufferTake(out ClientPacket packet)
+        {
+            return _receiveBuffer.TryDequeue(out packet);
+        }
+
     }
 
     public class Client
@@ -120,8 +181,6 @@ namespace Hybrasyl
         public static readonly ILog Logger = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
         public bool Connected => ClientState.Connected;
-
-        public bool IsReceiving { get; set; }
 
         public ClientState ClientState;
 
@@ -387,6 +446,148 @@ namespace Hybrasyl
             return key;
         }
 
+        public void FlushSendBuffer()
+        {
+            lock (ClientState.SendLock)
+            {
+                try
+                {
+                    ServerPacket packet;
+                    while (ClientState.SendBufferTake(out packet))
+                    {
+                        if (packet == null) return;
+
+                        if (packet.ShouldEncrypt)
+                        {
+                            ++ServerOrdinal;
+                            packet.Ordinal = ServerOrdinal;
+
+                            packet.GenerateFooter();
+                            packet.Encrypt(this);
+                        }
+                        if (packet.TransmitDelay != 0)
+                        {
+                            Thread.Sleep(packet.TransmitDelay);
+                        }
+
+                        var buffer = packet.ToArray();
+
+                        Socket.BeginSend(buffer, 0, buffer.Length, 0, SendCallback, ClientState);
+                    }
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Socket is gone, peace out
+                    ClientState.Dispose();
+                }
+                catch (Exception e)
+                {
+                    Logger.Error($"HALP: {e}");
+                }
+            }
+        }
+
+        public void FlushReceiveBuffer()
+        {
+            lock (ClientState.ReceiveLock)
+            {
+                try
+                {
+                    ClientPacket packet;
+                    while (ClientState.ReceiveBufferTake(out packet))
+                    {
+                        if (packet.ShouldEncrypt)
+                        {
+                            packet.Decrypt(this);
+                        }
+
+                        if (packet.Opcode == 0x39 || packet.Opcode == 0x3A)
+                            packet.DecryptDialog();
+                        try
+                        {
+                            if (Server is Lobby)
+                            {
+                                Logger.DebugFormat("Lobby: 0x{0:X2}", packet.Opcode);
+                                var handler = (Server as Lobby).PacketHandlers[packet.Opcode];
+                                handler.Invoke(this, packet);
+                                Logger.DebugFormat("Lobby packet done");
+                                UpdateLastReceived();
+                            }
+                            else if (Server is Login)
+                            {
+                                Logger.DebugFormat("Login: 0x{0:X2}", packet.Opcode);
+                                var handler = (Server as Login).PacketHandlers[packet.Opcode];
+                                handler.Invoke(this, packet);
+                                Logger.DebugFormat("Login packet done");
+                                UpdateLastReceived();
+                            }
+                            else
+                            {
+                                UpdateLastReceived(packet.Opcode != 0x45 &&
+                                                          packet.Opcode != 0x75);
+                                Logger.DebugFormat("Queuing: 0x{0:X2}", packet.Opcode);
+                                // Check for throttling
+                                var throttleResult = Server.PacketThrottleCheck(this, packet);
+                                if (throttleResult == ThrottleResult.OK || throttleResult == ThrottleResult.ThrottleEnd || throttleResult == ThrottleResult.SquelchEnd)
+                                {
+                                    World.MessageQueue.Add(new HybrasylClientMessage(packet, ConnectionId));
+                                }
+                            }
+
+                        }
+                        catch (Exception e)
+                        {
+                            Logger.ErrorFormat("EXCEPTION IN HANDLING: 0x{0:X2}: {1}", packet.Opcode, e);
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                    throw;
+                }
+            }
+        }
+
+        public void SendCallback(IAsyncResult ar)
+        {
+            ClientState state = (ClientState)ar.AsyncState;
+            Client client;
+
+            Logger.DebugFormat($"EndSend: SocketConnected: {state.WorkSocket.Connected}, IAsyncResult: Completed: {ar.IsCompleted}, CompletedSynchronously: {ar.CompletedSynchronously}");
+
+            try
+            {
+                SocketError errorCode;
+                var bytesSent = state.WorkSocket.EndSend(ar, out errorCode);
+                if (!GlobalConnectionManifest.ConnectedClients.TryGetValue(state.Id, out client))
+                {
+                    Logger.ErrorFormat("Send: socket should not exist: cid {0}", state.Id);
+                    state.WorkSocket.Close();
+                    state.WorkSocket.Dispose();
+                    return;
+                }
+
+                if (bytesSent == 0 || errorCode != SocketError.Success)
+                {
+                    Logger.ErrorFormat("cid {0}: disconnected");
+                    client.Disconnect();
+                    throw new SocketException((int)errorCode);
+                }
+            }
+            catch (SocketException e)
+            {
+                Logger.Fatal($"Error Code: {e.ErrorCode}, {e.Message}");
+                state.WorkSocket.Close();
+            }
+            catch (ObjectDisposedException)
+            {
+                //client.Disconnect();
+                state.WorkSocket.Close();
+            }
+            state.SendComplete.Set();
+        }
+
         public void GenerateKeyTable(string seed)
         {
             string table = Crypto.HashString(seed, "MD5");
@@ -401,8 +602,16 @@ namespace Hybrasyl
 
         public void Enqueue(ServerPacket packet)
         {
-            Logger.DebugFormat("Enqueueing {0}", packet.Opcode);
+            Logger.DebugFormat("Enqueueing ServerPacket {0}", packet.Opcode);
             ClientState.SendBufferAdd(packet);
+            FlushSendBuffer();
+        }
+
+        public void Enqueue(ClientPacket packet)
+        {
+            Logger.DebugFormat("Enqueueing ClientPacket {0}", packet.Opcode);
+            ClientState.ReceiveBufferAdd(packet);
+            FlushReceiveBuffer();
         }
 
         public void Redirect(Redirect redirect, bool isLogoff = false)

--- a/hybrasyl/Game.cs
+++ b/hybrasyl/Game.cs
@@ -373,32 +373,15 @@ namespace Hybrasyl
             _loginThread = new Thread(new ThreadStart(Login.StartListening));
             _worldThread = new Thread(new ThreadStart(World.StartListening));
 
-            _lobbySendThread = new Thread(new ThreadStart(Lobby.SendLoop));
-            _loginSendThread = new Thread(new ThreadStart(Login.SendLoop));
-            _worldSendThread = new Thread(new ThreadStart(World.SendLoop));
-
             _spawnThread = new Thread(_monolith.Start);
-
             _controlThread = new Thread(_monolithControl.Start);
-
-            //foreach (var control in _monolithControls)
-            //{
-            //    Task.Run(() =>
-            //    {
-            //        control.Start();
-            //    });
-            //}
 
             _lobbyThread.Start();
             _loginThread.Start();
             _worldThread.Start();
-
-            _lobbySendThread.Start();
-            _loginSendThread.Start();
-            _worldSendThread.Start();
-
             _spawnThread.Start();
             _controlThread.Start();
+
             while (true)
             {
                 if (!IsActive())
@@ -408,11 +391,14 @@ namespace Hybrasyl
                 }
                 Thread.Sleep(100);
             }
+
             Logger.Warn("Hybrasyl: all servers shutting down");
+
             // Server is shutting down. For Lobby and Login, this terminates the TCP listeners;
             // for World, this triggers a logoff for all logged in users and then terminates. After
             // termination, the queue consumer is stopped as well.
             // For a true restart we'll need to do a few other things; stop timers, etc.
+
             host.Close();
             Lobby.Shutdown();
             Login.Shutdown();

--- a/hybrasyl/Server.cs
+++ b/hybrasyl/Server.cs
@@ -108,86 +108,6 @@ namespace Hybrasyl
             }
         }
 
-
-        public void SendLoop()
-        {
-            while (true)
-            {
-                if (StopToken.IsCancellationRequested)
-                    return;
-                //Logger.InfoFormat("GCM value: {0}", GlobalConnectionManifest.ConnectedClients.Count);
-                foreach (var client in GlobalConnectionManifest.ConnectedClients.Select(kvp => kvp.Value))
-                {
-                    try
-                    {
-                        if (client.IsReceiving) continue;
-                        
-                        ServerPacket packet;
-                        if (!client.ClientState.SendBufferTake(out packet)) continue;
-                        if (packet.ShouldEncrypt)
-                        {
-                            ++client.ServerOrdinal;
-                            packet.Ordinal = client.ServerOrdinal;
-
-                            packet.GenerateFooter();
-                            packet.Encrypt(client);
-                        }
-                        if (packet.TransmitDelay != 0)
-                        {
-                            Thread.Sleep(packet.TransmitDelay);
-                        }
-                        var buffer = packet.ToArray();
-
-                        var byteData = (byte[]) packet;
-                        if (client.ClientState.WorkSocket.Connected)
-                        {
-                            try
-                            {
-                                client.ClientState.WorkSocket.BeginSend(buffer, 0, buffer.Length, 0,
-                                new AsyncCallback(SendCallback), client.ClientState);
-                            }
-                            catch (SocketException e)
-                            {
-                                Logger.Fatal(e.Message);
-                                client.Disconnect();
-                            }
-                            
-                        }
-
-                    }
-                    catch (Exception e)
-                    {
-                       Logger.Fatal(e.Message);
-                    }
-                    
-                }
-                
-                Thread.Sleep(100);
-            }
-        }
-
-       
-
-        public byte[] SendPacket(Client client, ServerPacket packet)
-        {
-            if (packet == null) return null;
-            if (packet.ShouldEncrypt)
-            {
-                ++client.ServerOrdinal;
-                packet.Ordinal = client.ServerOrdinal;
-
-                packet.GenerateFooter();
-                packet.Encrypt(client);
-            }
-            if (packet.TransmitDelay != 0)
-            {
-                Thread.Sleep(packet.TransmitDelay);
-            }
-            var buffer = packet.ToArray();
-
-            return buffer;
-        }
-
         public virtual void AcceptConnection(IAsyncResult ar)
         {
             // TODO: @norrismiv async callbacks+inheritance? and/or can these callbacks suck less?
@@ -230,88 +150,16 @@ namespace Hybrasyl
             }
         }
 
-        public void SendCallback(IAsyncResult ar)
-             {
-
-            ClientState state = (ClientState) ar.AsyncState;
-            Client client;
-            Logger.DebugFormat("EndSend");
-            try
-            {
-                SocketError errorCode;
-                var bytesSent = state.WorkSocket.EndSend(ar, out errorCode);
-                if (!GlobalConnectionManifest.ConnectedClients.TryGetValue(state.Id, out client))
-                {
-                    Logger.ErrorFormat("Send: socket should not exist: cid {0}", state.Id);
-                    state.WorkSocket.Close();
-                    state.WorkSocket.Dispose();
-                    return;
-                }
-
-                if (bytesSent == 0 || errorCode != SocketError.Success)
-                {
-                    Logger.ErrorFormat("cid {0}: disconnected");
-                    client.Disconnect();
-                    throw new SocketException((int)errorCode);
-                }
-            }
-            catch (SocketException e)
-            {
-                Logger.Fatal($"Error Code: {e.ErrorCode}, {e.Message}");
-                state.WorkSocket.Close();
-            }
-            catch (ObjectDisposedException)
-            {
-                //client.Disconnect();
-                state.WorkSocket.Close();
-            }
-        }
-
-        private void Send(ClientState handler, byte[] packet)
-        {
-            try
-            {
-                if (packet == null) return;
-                handler.WorkSocket.BeginSend(packet, 0, packet.Length, SocketFlags.None, new AsyncCallback(SendCallback), handler);
-            }
-            catch (Exception e)
-            {
-                Logger.Fatal(e.Message);
-                throw;
-            }
-
-        }
-
         public void ReadCallback(IAsyncResult ar)
         {
-            ClientState state = (ClientState) ar.AsyncState;
+            ClientState state = (ClientState)ar.AsyncState;
             Client client;
             SocketError errorCode = SocketError.SocketError;
             int bytesRead = 0;
+            ClientPacket receivedPacket;
 
-            try
-            {
-                bytesRead = state.WorkSocket.EndReceive(ar, out errorCode);
-                if (errorCode != SocketError.Success)
-                {
-                    bytesRead = 0;
-                }
-                else if (errorCode == SocketError.NoData || errorCode == SocketError.AccessDenied ||
-                         errorCode == SocketError.Fault || errorCode == SocketError.InvalidArgument ||
-                         errorCode == SocketError.NoBufferSpaceAvailable)
-                {
-                    throw new SocketException((int) errorCode);
-                }
-            }
-            catch (SocketException e)
-            {
-                Logger.Fatal($"ErrorCode: {e.ErrorCode}, {e.Message}");
-                state.WorkSocket.Close();
-            }
-            catch (ObjectDisposedException)
-            {
-                state.WorkSocket.Close();
-            }
+            Logger.Debug($"SocketConnected: {state.WorkSocket.Connected}, IAsyncResult: Completed: {ar.IsCompleted}, CompletedSynchronously: {ar.CompletedSynchronously}, queue size: {state.Buffer.Length}");
+            Logger.Debug("Running read callback");
 
             if (!GlobalConnectionManifest.ConnectedClients.TryGetValue(state.Id, out client))
             {
@@ -329,120 +177,27 @@ namespace Hybrasyl
                 GlobalConnectionManifest.RegisterClient(client);
             }
 
-            if (bytesRead > 0)
+            try
             {
-
-                var inboundBytes = state.ReceiveBufferTake(bytesRead).ToArray();
-                if (inboundBytes[0] != 0xAA)
+                bytesRead = state.WorkSocket.EndReceive(ar, out errorCode);
+                if (bytesRead == 0 || errorCode != SocketError.Success)
                 {
-                    Logger.DebugFormat("cid {0}: client is sending corrupt data, potentially",
-                        client.ConnectionId);
-                    state.ResetReceive();
-                }
-                else
-                {
-                    while (inboundBytes.Length > 3)
-                    {
-                        var packetLength = ((int) inboundBytes[1] << 8) + (int) inboundBytes[2] + 3;
-                        if (packetLength > inboundBytes.Length)
-                        {
-                            // We haven't received the entire packet yet; read more bytes
-                            break;
-                        }
-                        else
-                        {
-                            // We've received an intact packet, pop it off
-                            ClientPacket receivedPacket =
-                                new ClientPacket(state.ReceiveBufferPop(packetLength).ToArray());
-                            // Also remove it from our local buffer...this seems kinda gross to me
-                            inboundBytes =
-                                new List<byte>(inboundBytes).GetRange(packetLength,
-                                        inboundBytes.Length - packetLength)
-                                    .ToArray();
-
-                            if (receivedPacket.ShouldEncrypt)
-                            {
-                                receivedPacket.Decrypt(client);
-                            }
-                            if (receivedPacket.Opcode == 0x39 || receivedPacket.Opcode == 0x3A)
-                                receivedPacket.DecryptDialog();
-                            try
-                            {
-                                if (this is Lobby)
-                                {
-                                    Logger.DebugFormat("Lobby: 0x{0:X2}", receivedPacket.Opcode);
-                                    var handler = (this as Lobby).PacketHandlers[receivedPacket.Opcode];
-                                    handler.Invoke(client, receivedPacket);
-                                    if (!client.IsReceiving)
-                                    {
-                                        client.IsReceiving = true;
-                                        ServerPacket sendBuff;
-                                        state.SendBufferTake(out sendBuff);
-                                        Send(state, SendPacket(client, sendBuff));
-                                        client.IsReceiving = false;
-                                    }
-                                    Logger.DebugFormat("Lobby packet done");
-                                    client.UpdateLastReceived();
-                                }
-                                else if (this is Login)
-                                {
-                                    Logger.DebugFormat("Login: 0x{0:X2}", receivedPacket.Opcode);
-                                    var handler = (this as Login).PacketHandlers[receivedPacket.Opcode];
-                                    handler.Invoke(client, receivedPacket);
-                                    if (!client.IsReceiving)
-                                    {
-                                        client.IsReceiving = true;
-                                        ServerPacket sendBuff;
-                                        state.SendBufferTake(out sendBuff);
-                                        Send(state, SendPacket(client, sendBuff));
-                                        client.IsReceiving = false;
-                                    }
-                                    Logger.DebugFormat("Login packet done");
-                                    client.UpdateLastReceived();
-                                }
-                                else
-                                {
-                                    client.UpdateLastReceived(receivedPacket.Opcode != 0x45 &&
-                                                              receivedPacket.Opcode != 0x75);
-                                    Logger.DebugFormat("Queuing: 0x{0:X2}", receivedPacket.Opcode);
-                                    // Check for throttling
-                                    var throttleResult = PacketThrottleCheck(client, receivedPacket);
-                                    if (throttleResult == ThrottleResult.OK || throttleResult == ThrottleResult.ThrottleEnd || throttleResult == ThrottleResult.SquelchEnd)
-                                    {
-                                        World.MessageQueue.Add(new HybrasylClientMessage(receivedPacket,
-                                            client.ConnectionId));
-                                    }
-                                    if (!client.IsReceiving)
-                                    {
-                                        client.IsReceiving = true;
-                                        ServerPacket sendBuff;
-                                        state.SendBufferTake(out sendBuff);
-                                        Send(state, SendPacket(client, sendBuff));
-                                        client.IsReceiving = false;
-                                    }
-                                }
-                            }
-                            catch (Exception e)
-                            {
-                                Logger.ErrorFormat("EXCEPTION IN HANDLING: 0x{0:X2}: {1}", receivedPacket.Opcode, e);
-                            }
-
-                        }
-                    }
-                }
-            }
-            else
-            {
-                if (errorCode != SocketError.Success)
-                {
-                    Logger.DebugFormat("cid {0}: client is disconnected or corrupt packets received",
-                        client.ConnectionId);
+                    Logger.Error($"bytesRead: {bytesRead}, errorCode: {errorCode}");
                     client.Disconnect();
                 }
-                return;
+            }
+            catch (Exception e)
+            {
+                Logger.Fatal($"EndReceive Error:  {e.Message}");
+                client.Disconnect();
+            }
+
+            // TODO: improve / refactor
+            while (client.ClientState.TryGetPacket(out receivedPacket))
+            {
+                client.Enqueue(receivedPacket);
             }
             ContinueReceiving(state, client);
-
         }
 
         private void ContinueReceiving(ClientState state, Client client)


### PR DESCRIPTION
## Description
This PR updates sending and receiving in Hybrasyl to be completely asynchronous, and removes any legacy packet processing code we had from when Hybrasyl was still single threaded. Sending and receiving now follow the same pattern, as well, and most functionality has been moved into `Client` / `ClientState`.

@norrismiv and I consider this to be a fix to the "socket problems"; testing under load will demonstrate that this is a definitive fix.

## Related PRs
None.

## Checklist
- [x] Tested and working locally
- [x] Reviewed
- [ ] Tested and working on dev server
- [ ] Deployed to staging

## How to QA
Make lots of bees. Note that the bees (and the packets they generate) do not crash the server or client or result in strange disconnects.

## Impacted Areas in Hybrasyl
Network receive / send.
