### PR TITLE
Fix #138: use active users for who list / ensure shutdown works correctly

### DIFF
--- a/hybrasyl/Game.cs
+++ b/hybrasyl/Game.cs
@@ -396,13 +396,14 @@ namespace Hybrasyl
             // termination, the queue consumer is stopped as well.
             // For a true restart we'll need to do a few other things; stop timers, etc.
 
-            host.Close();
             Lobby.Shutdown();
             Login.Shutdown();
             World.Shutdown();
+            Thread.Sleep(5000);
             World.StopQueueConsumer();
             World.StopControlConsumers();
             Logger.WarnFormat("Hybrasyl {0}: shutdown complete.", Assemblyinfo.Version);
+            host.Close();
             Environment.Exit(0);
 
         }

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -3518,12 +3518,17 @@ namespace Hybrasyl.Objects
             return Client.IsHeartbeatExpired();
         }
 
-        public void Logoff()
+        public void Logoff(bool disconnect = false)
         {
-                UpdateLogoffTime();
-                Save();
+            UpdateLogoffTime();
+            Save();
+            if (!disconnect)
+            {
                 var redirect = new Redirect(Client, Game.World, Game.Login, "socket", Client.EncryptionSeed, Client.EncryptionKey);
                 Client.Redirect(redirect, true);
+            }
+            else
+                Client.Socket.Disconnect(true);
         }
 
         public void SetEncryptionParameters(byte[] key, byte seed, string name)

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -1079,10 +1079,11 @@ namespace Hybrasyl
         {
             Logger.WarnFormat("Shutdown initiated, disconnecting {0} active users", ActiveUsers.Count);
 
+            Active = false;
             foreach (var connection in ActiveUsers)
             {
                 var user = connection.Value;
-                user.Logoff();
+                user.Logoff(true);
             }
             Listener.Close();
             Logger.Warn("Shutdown complete");
@@ -1172,7 +1173,7 @@ namespace Hybrasyl
             {
                 var user = connection.Value;
                 user.SendMessage("Chaos is rising up. Please re-enter in a few minutes.",
-                    Hybrasyl.MessageTypes.SYSTEM_WITH_OVERHEAD);
+                    MessageTypes.SYSTEM_WITH_OVERHEAD);
             }
 
             // Actually shut down the server. This terminates the listener loop in Game.
@@ -1728,7 +1729,7 @@ namespace Hybrasyl
         {
             var me = (User)obj;
 
-            var list = from user in WorldData.Values<User>()
+            var list = from user in ActiveUsers.Values
                        orderby user.IsMaster descending, user.Stats.Level descending, user.Stats.BaseHp + user.Stats.BaseMp * 2 descending, user.Name ascending
                        select user;
 


### PR DESCRIPTION
## Description

This PR fixes #138 and ensures that an orderly shutdown occurs (with no unhandled exceptions / etc) when the server is shut down using the REST control service.

## Related PRs
n/a

## Checklist
- [X] Tested and working locally
- [ ] Reviewed
- [ ] Tested and working on dev server
- [ ] Deployed to staging

## How to QA

User list: 

1) Log on more than once.
2) Confirm that who list shows correct number of users.
3) Log one user off.
4) Confirm who list does not show the logged off user.

Shutdown: 

1) Use the ControlService to shutdown the server. 
Powershell command that can be used to test this:
`Invoke-RestMethod -Uri http://127.0.0.1:4949/ControlService/Shutdown/<shutdownpassword>`

2) The server should shut down (all users get "Chaos is rising up" followed by disconnects)
3) You should get a successful response from `Invoke-RestMethod`
4) server should close (exit) without incident (e.g. no unhandled exceptions or crashing).

## Impacted Areas in Hybrasyl
Finally using `Active` in Server.cs, socket handling areas.

