### PR TITLE
Ensure we redisplay equipment correctly on login (#129)

### DIFF
--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -3668,9 +3668,10 @@ namespace Hybrasyl.Objects
 
         public void SendEquipment()
         {
-            foreach (var item in Equipment)
+            for (byte i=0; i < Equipment.Size; i++)
             {
-                SendEquipItem(item, item.EquipmentSlot);
+                if (Equipment[i] != null)
+                    SendEquipItem(Equipment[i], i);
             }
         }
         public void SendSkills()


### PR DESCRIPTION
## Description
Fix a bug where we weren't sending the correct equipment packets on re-login. Specifically for rings, this was causing an issue where we were sending incorrect item slots, resulting in a ring appearing as a stave and no rings showing up.

## Related PRs
n/a

## Checklist
- [X] Tested and working locally
- [ ] Reviewed
- [ ] Tested and working on dev server
- [ ] Deployed to staging

## How to QA
1. Equip a full slate of equipment. Confirm that it all displays correctly.
2. Logoff.
3. Log back in and verify that the equipment was not only correctly re-equipped, but also displays correctly in your profile screen.

## Impacted Areas in Hybrasyl
Login only, this is the result of an edge case rather than a general equipment / inventory display bug
