### PR TITLE
Mileth scripting

### DIFF
--- a/HybrasylXML/XSD/hybrasylConfig.Designer.cs
+++ b/HybrasylXML/XSD/hybrasylConfig.Designer.cs
@@ -17,7 +17,7 @@ namespace Hybrasyl.Config
     using System.Collections.Generic;
 
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -149,7 +149,7 @@ namespace Hybrasyl.Config
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -215,7 +215,7 @@ namespace Hybrasyl.Config
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Config")]
     public enum LogLevel
@@ -243,7 +243,7 @@ namespace Hybrasyl.Config
         None,
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -292,7 +292,7 @@ namespace Hybrasyl.Config
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -356,7 +356,7 @@ namespace Hybrasyl.Config
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -405,7 +405,7 @@ namespace Hybrasyl.Config
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -469,7 +469,7 @@ namespace Hybrasyl.Config
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -525,7 +525,7 @@ namespace Hybrasyl.Config
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -650,7 +650,7 @@ namespace Hybrasyl.Config
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -689,7 +689,7 @@ namespace Hybrasyl.Config
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -753,7 +753,7 @@ namespace Hybrasyl.Config
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -771,6 +771,12 @@ namespace Hybrasyl.Config
         private int _startYear;
         #endregion
 
+        public HybrasylAge()
+        {
+            this._startYear = 1;
+        }
+
+        [System.Xml.Serialization.XmlAttributeAttribute()]
         public string Name
         {
             get
@@ -783,6 +789,7 @@ namespace Hybrasyl.Config
             }
         }
 
+        [System.Xml.Serialization.XmlAttributeAttribute()]
         public System.DateTime StartDate
         {
             get
@@ -795,6 +802,7 @@ namespace Hybrasyl.Config
             }
         }
 
+        [System.Xml.Serialization.XmlAttributeAttribute()]
         public System.DateTime EndDate
         {
             get
@@ -807,6 +815,8 @@ namespace Hybrasyl.Config
             }
         }
 
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        [System.ComponentModel.DefaultValueAttribute(1)]
         public int StartYear
         {
             get
@@ -820,7 +830,7 @@ namespace Hybrasyl.Config
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -860,7 +870,7 @@ namespace Hybrasyl.Config
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -916,7 +926,7 @@ namespace Hybrasyl.Config
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -971,7 +981,7 @@ namespace Hybrasyl.Config
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -996,7 +1006,7 @@ namespace Hybrasyl.Config
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1037,7 +1047,7 @@ namespace Hybrasyl.Config
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1082,7 +1092,7 @@ namespace Hybrasyl.Config
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1129,7 +1139,7 @@ namespace Hybrasyl.Config
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1189,7 +1199,7 @@ namespace Hybrasyl.Config
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.2556.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.7.3056.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]

--- a/HybrasylXML/XSD/hybrasylConfig.xsd
+++ b/HybrasylXML/XSD/hybrasylConfig.xsd
@@ -128,12 +128,10 @@
   </xs:complexType>
 
   <xs:complexType name="HybrasylAge">
-    <xs:sequence>
-      <xs:element name="Name" type="hyb:String5" minOccurs="1" maxOccurs="1"/>
-      <xs:element name="StartDate" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
-      <xs:element name="EndDate" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="StartYear" type="xs:int" minOccurs="0" maxOccurs="1"/>
-    </xs:sequence>
+    <xs:attribute name="Name" type="hyb:String5" use="required"/>
+    <xs:attribute name="StartDate" type="xs:dateTime" use="required"/>
+    <xs:attribute name="EndDate" type="xs:dateTime" use="optional"/>
+    <xs:attribute name="StartYear" type="xs:int" default="1"/>
   </xs:complexType>
   
   <xs:complexType name="HybrasylAges">

--- a/HybrasylXML/XSD/hybrasylExtensions.cs
+++ b/HybrasylXML/XSD/hybrasylExtensions.cs
@@ -293,15 +293,72 @@ namespace Hybrasyl.Statuses
 
 namespace Hybrasyl.Config
 {
+
+    public partial class Time
+    {
+
+        public HybrasylAge DefaultAge => new HybrasylAge() { Name = "Hybrasyl", StartYear = 1 };
+
+        /// <summary>
+        /// Try to find the previous age for a given age. Return false if there is no previous age 
+        /// (in which case, a Hybrasyl date before the beginning of the age is simply a negative year)
+        /// </summary>
+        /// <param name="age"></param>
+        /// <param name="previousAge"></param>
+        /// <returns></returns>
+        public bool TryGetPreviousAge(HybrasylAge age, out HybrasylAge previousAge)
+        {
+            previousAge = null;
+            if (Ages.Count == 1)
+                return false;
+            // Find the age of the day before the start date. This assumes the 
+            // user hasn't done something doltish like having non-contiguous ages
+            var before = age.StartDate - new TimeSpan(1, 0, 0, 0);
+            previousAge = Ages.FirstOrDefault(a => a.DateInAge(before));
+            return previousAge != null;
+        }
+
+        /// <summary>
+        /// Try to find the next age for a given age. Return false if there is no next age 
+        /// (in which case, the Hybrasyl year simply increments without end)
+        /// </summary>
+        /// <param name="age"></param>
+        /// <param name="nextAge"></param>
+        /// <returns></returns>
+        public bool TryGetNextAge(HybrasylAge age, out HybrasylAge nextAge)
+        {
+            nextAge = null;
+            if (Ages.Count == 1)
+                return false;
+            // Find the age of the day after the start date. This (again) assumes the 
+            // user hasn't done something doltish like having non-contiguous ages
+            var after = age.StartDate + new TimeSpan(1, 0, 0, 0);
+            nextAge = Ages.FirstOrDefault(a => a.DateInAge(after));
+            return nextAge != null;
+        }
+    
+
+        public HybrasylAge GetAgeFromTerranDatetime(DateTime datetime)
+        {
+            if (Ages.Count == 0)
+                return DefaultAge;
+            else if (Ages.Count == 1)
+                return Ages.First();
+            else
+                return Ages.First(a => a.DateInAge(datetime));
+        }
+    }
+
     public partial class HybrasylAge
     {
 
         public bool DateInAge(DateTime datetime)
         {
-            if (EndDate == null) return datetime.Ticks > StartDate.Ticks;
+            if (EndDate == default(DateTime)) return datetime.Ticks > StartDate.Ticks;
             var endDate = (DateTime)EndDate;
             return datetime.Ticks >= StartDate.Ticks && datetime.Ticks <= endDate.Ticks;
         }
+
     }
 }
 

--- a/hybrasyl/Board.cs
+++ b/hybrasyl/Board.cs
@@ -46,7 +46,7 @@ namespace Hybrasyl
             if (IsSaving) return;
             IsSaving = true;
             var cache = World.DatastoreConnection.GetDatabase();
-            cache.Set(StorageKey, JsonConvert.SerializeObject(this));
+            cache.Set(StorageKey, this);
             IsSaving = false;
         }
 

--- a/hybrasyl/Legend.cs
+++ b/hybrasyl/Legend.cs
@@ -23,6 +23,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using Hybrasyl.Enums;
 using Newtonsoft.Json;
 
@@ -34,7 +35,8 @@ namespace Hybrasyl
     {
         public const int MaximumLegendSize = 254;
 
-        [JsonProperty] private SortedDictionary<DateTime, LegendMark> _legend =
+        [JsonProperty]
+        private SortedDictionary<DateTime, LegendMark> _legend =
             new SortedDictionary<DateTime, LegendMark>();
 
         private Dictionary<string, LegendMark> _legendIndex = new Dictionary<string, LegendMark>();
@@ -49,7 +51,7 @@ namespace Hybrasyl
             if (_legend.Keys.Count == MaximumLegendSize) return false;
             if (!string.IsNullOrEmpty(mark.Prefix) && _legendIndex.ContainsKey(mark.Prefix))
                 throw new ArgumentException("A legend mark's prefix must be unique for a given character");
-            _legend.Add(mark.Created, mark);
+            _legend.Add(mark.Timestamp, mark);
             _legendIndex[mark.Prefix] = mark;
             return true;
         }
@@ -59,23 +61,29 @@ namespace Hybrasyl
             LegendMark mark;
             if (!_legendIndex.TryGetValue(prefix, out mark)) return false;
             _legendIndex.Remove(prefix);
-            _legend.Remove(mark.Created);
+            _legend.Remove(mark.Timestamp);
             return true;
         }
 
-        public bool AddMark(LegendIcon icon, LegendColor color, string text, DateTime created,
-            string prefix = default(string), bool isPublic = true, int quantity = 0)
+        public bool AddMark(LegendIcon icon, LegendColor color, string text, DateTime timestamp,
+            string prefix = default(string), bool isPublic = true, int quantity = 0, bool displaySeason = true, bool displayTimestamp = true)
         {
-            var newMark = new LegendMark(icon, color, text, created, prefix, isPublic, quantity);
+            var newMark = new LegendMark(icon, color, text, timestamp, prefix, isPublic, quantity, displaySeason, displayTimestamp);
             return _addLegendMark(newMark);
         }
 
         public bool AddMark(LegendIcon icon, LegendColor color, string text, string prefix = default(string),
-            bool isPublic = true, int quantity = 0)
+            bool isPublic = true, int quantity = 0, bool displaySeason = true, bool displayTimestamp = true)
         {
             var datetime = DateTime.Now;
-            var newMark = new LegendMark(icon, color, text, datetime, prefix, isPublic, quantity);
+            var newMark = new LegendMark(icon, color, text, datetime, prefix, isPublic, quantity, displaySeason, displayTimestamp);
             return _addLegendMark(newMark);
+        }
+
+        [OnDeserialized]
+        private void _CreateIndex(StreamingContext context)
+        {
+            RegenerateIndex();
         }
 
         public void RegenerateIndex()
@@ -107,20 +115,36 @@ namespace Hybrasyl
         }
     }
 
-    [JsonObject]
+    [JsonObject(MemberSerialization.OptIn)]
     public class LegendMark
     {
+        [JsonProperty]
         public string Prefix { get; set; }
+        [JsonProperty]
         public LegendColor Color { get; set; }
+        [JsonProperty]
         public LegendIcon Icon { get; set; }
+        [JsonProperty]
         public string Text { get; set; }
+        [JsonProperty]
         public bool Public { get; set; }
+        [JsonProperty]
+        public bool DisplaySeason { get; set; }
+        [JsonProperty]
+        public bool DisplayTimestamp { get; set; }
+        [JsonProperty]
+        public DateTime Timestamp { get; set; }
+        [JsonProperty]
         public DateTime Created { get; }
+        [JsonProperty]
         public DateTime LastUpdated { get; set; }
+        [JsonProperty]
         public int Quantity { get; set; }
 
-        public LegendMark(LegendIcon icon, LegendColor color, string text, DateTime created,
-            string prefix = default(string), bool isPublic = true, int quantity = 0)
+        public HybrasylTime HybrasylDate => HybrasylTime.ConvertToHybrasyl(Timestamp);
+
+        public LegendMark(LegendIcon icon, LegendColor color, string text, DateTime timestamp,
+            string prefix = default(string), bool isPublic = true, int quantity = 0, bool displaySeason=true, bool displayTimestamp=true)
         {
             Icon = icon;
             Color = color;
@@ -128,8 +152,11 @@ namespace Hybrasyl
             Public = isPublic;
             Quantity = quantity;
             Prefix = prefix;
-            Created = created;
-            LastUpdated = created;
+            Timestamp = timestamp;
+            Created = DateTime.Now;
+            LastUpdated = DateTime.Now;
+            DisplaySeason = displaySeason;
+            DisplayTimestamp = displayTimestamp;
         }
 
         public void AddQuantity(int quantity)
@@ -140,9 +167,13 @@ namespace Hybrasyl
 
         public override string ToString()
         {
-            var aislingDate = HybrasylTime.ConvertToHybrasyl(Created != LastUpdated ? Created : LastUpdated);
+            var aislingDate = HybrasylTime.ConvertToHybrasyl(Timestamp != LastUpdated ? Timestamp : LastUpdated);
             var returnstring = Text;
-            var markDate = $"{aislingDate.Age} {aislingDate.Year}, {aislingDate.Season}";
+            string markDate = "";
+            if (DisplayTimestamp && DisplaySeason)
+                markDate = $"{aislingDate.AgeName} {aislingDate.Year}, {aislingDate.Season}";
+            else if (DisplayTimestamp)
+                markDate = $"{aislingDate.AgeName} {aislingDate.Year}";
 
             var maxLength = 254 - 15 - markDate.Length;
 

--- a/hybrasyl/Login.cs
+++ b/hybrasyl/Login.cs
@@ -193,8 +193,7 @@ namespace Hybrasyl
                 newPlayer.Nation = Game.World.DefaultNation;
 
                 IDatabase cache = World.DatastoreConnection.GetDatabase();
-                var myPerson = JsonConvert.SerializeObject(newPlayer);
-                cache.Set(User.GetStorageKey(newPlayer.Name), myPerson);
+                cache.Set(User.GetStorageKey(newPlayer.Name), newPlayer);
 
 //                    Logger.ErrorFormat("Error saving new player!");
   //                  Logger.ErrorFormat(e.ToString());

--- a/hybrasyl/Map.cs
+++ b/hybrasyl/Map.cs
@@ -266,6 +266,8 @@ namespace Hybrasyl
                     merchant.Roles = npcTemplate.Roles;
                 }
                 InsertNpc(merchant);
+                // Keep the actual spawned object around in the index for later use
+                World.WorldData.Set(merchant.Name, merchant);
             }
 
             foreach (var reactorElement in newMap.Reactors)

--- a/hybrasyl/Messaging/Admin.cs
+++ b/hybrasyl/Messaging/Admin.cs
@@ -8,6 +8,23 @@ using System.Net;
 namespace Hybrasyl.Messaging
 {
     // Various admin commands are implemented here.
+    
+    class ShowCookies : ChatCommand
+    {
+        public new static string Command = "showcookies";
+        public new static string ArgumentText = "<string playername>";
+        public new static string HelpText = "Show permanent and session cookies set for a specified player";
+        public new static bool Privileged = true;
+
+        public new static ChatCommandResult Run(User user, params string [] args)
+        {
+            if (Game.World.WorldData.TryGetValue<User>(args[0], out User target))
+            {
+                return Success($"User {target.Name} Cookies\n\n{target.GetCookies()}\n\nSession Cookies\n\n{target.GetSessionCookies()}", MessageTypes.SLATE_WITH_SCROLLBAR);
+            }
+            return Fail($"User {args[0]} not logged in");
+        }
+    }
 
     class SummonCommand : ChatCommand
     {

--- a/hybrasyl/Messaging/Admin.cs
+++ b/hybrasyl/Messaging/Admin.cs
@@ -249,6 +249,84 @@ namespace Hybrasyl.Messaging
         }
     }
 
+    class DeleteSessionCookie : ChatCommand
+    {
+        public new static string Command = "deletesessioncookie";
+        public new static string ArgumentText = "<string cookie> | <string playername> <string cookie>";
+        public new static string HelpText = "Clear (delete) a given session (transient) scripting cookie. This is useful when working with scripts that modify player state.";
+        public new static bool Privileged = true;
+
+        public new static ChatCommandResult Run(User user, params string[] args)
+        {
+            if (args.Length == 1)
+            {
+                user.DeleteSessionCookie(args[0]);
+                return Success($"Session flag {args[0]} deleted.");
+            }
+            else
+            {
+                var target = Game.World.WorldData.Get<User>(args[0]);
+
+                if (target.IsExempt)
+                    return Fail($"User {target.Name} is exempt from your meddling.");
+                else
+                    target.DeleteSessionCookie(args[1]);
+                return Success($"Player {target.Name}: flag {args[1]} removed.");
+            }
+        }
+    }
+
+    class DeleteCookie : ChatCommand
+    {
+        public new static string Command = "deletecookie";
+        public new static string ArgumentText = "<string cookie> | <string playername> <string cookie>";
+        public new static string HelpText = "Clear (delete) a given scripting cookie. This is useful when working with scripts that modify player state.";
+        public new static bool Privileged = true;
+
+        public new static ChatCommandResult Run(User user, params string[] args)
+        {
+            if (args.Length == 1)
+            {
+                user.DeleteCookie(args[0]);
+                return Success($"Session flag {args[0]} deleted.");
+            }
+            else
+            {
+                var target = Game.World.WorldData.Get<User>(args[0]);
+
+                if (target.IsExempt)
+                    return Fail($"User {target.Name} is exempt from your meddling.");
+                else
+                    target.DeleteCookie(args[1]);
+                return Success($"Player {target.Name}: flag {args[1]} removed.");
+            }
+        }
+    }
+
+    class ReloadnpcCommand : ChatCommand
+    {
+        public new static string Command = "reloadnpc";
+        public new static string ArgumentText = "<string npcname>";
+        public new static string HelpText = "Reload the given NPC (dump the script and reload from disk)";
+        public new static bool Privileged = true;
+
+        public new static ChatCommandResult Run(User user, params string[] args)
+        {
+            if (Game.World.WorldData.TryGetValue(args[0], out Merchant merchant))
+            {
+                if (Game.World.ScriptProcessor.TryGetScript(merchant.Name, out Script script))
+                {
+                    script.Reload();
+                    merchant.Ready = false; // Force reload next time NPC processes an interaction
+                    return Success($"NPC {args[0]} - script {script.Name} reloaded. Clicking should re-run OnSpawn.");
+                }
+                else return Fail("NPC found but script not found...?");
+            }
+            else return Fail($"NPC {args[0]} not found.");
+
+        }
+    }
+
     class TeleportCommand : ChatCommand
     {
         public new static string Command = "teleport";

--- a/hybrasyl/Objects/Merchant.cs
+++ b/hybrasyl/Objects/Merchant.cs
@@ -59,6 +59,8 @@ namespace Hybrasyl.Objects
             {
                 Script = script;
                 Script.AssociateScriptWithObject(this);
+                // Clear existing pursuits, in case the OnSpawn crashes / has a bug
+                ResetPursuits();
                 Ready = Script.ExecuteFunction("OnSpawn");
             }
         }

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -196,8 +196,9 @@ namespace Hybrasyl.Objects
         public DialogState DialogState { get; set; }
 
         [JsonProperty]
-        private Dictionary<string, string> UserFlags { get; set; }
-        private Dictionary<string, string> UserSessionFlags { get; set; }
+        private Dictionary<string, string> UserCookies { get; set; }
+        // These are SESSION ONLY, they persist until logout / disconnect
+        private Dictionary<string, string> UserSessionCookies { get; set; }
 
         public Exchange ActiveExchange { get; set; }
 
@@ -335,6 +336,16 @@ namespace Hybrasyl.Objects
             Enqueue(removePacket);
         }
 
+        /// <summary>
+        /// Send a close dialog packet to the client. This will terminate any open dialog.
+        /// </summary>
+        public void SendCloseDialog()
+        {
+            var p = new ServerPacket(0x30);
+            p.WriteByte(0x0A);
+            p.WriteByte(0x00);
+            Enqueue(p);
+        }
 
         /// <summary>T
         /// Send a status bar update to the client based on the state of a given status.
@@ -597,8 +608,8 @@ namespace Hybrasyl.Objects
             PortraitData = new byte[0];
             ProfileText = string.Empty;
             DialogState = new DialogState(this);
-            UserFlags = new Dictionary<string, string>();
-            UserSessionFlags = new Dictionary<string, string>();
+            UserCookies = new Dictionary<string, string>();
+            UserSessionCookies = new Dictionary<string, string>();
             Group = null;
             Flags = new Dictionary<string, bool>();
             _currentStatuses = new ConcurrentDictionary<ushort, ICreatureStatus>();
@@ -1439,36 +1450,42 @@ namespace Hybrasyl.Objects
             Enqueue(x17);
         }
 
-        public void SetFlag(string flag, string value)
+        public void SetCookie(string cookieName, string value)
         {
-            UserFlags[flag] = value;
+            UserCookies[cookieName] = value;
         }
 
-        public void SetSessionFlag(string flag, string value)
+        public void SetSessionCookie(string cookieName, string value)
         {
-            UserSessionFlags[flag] = value;
+            UserSessionCookies[cookieName] = value;
         }
 
-        public string GetFlag(string flag)
+        public string GetCookie(string cookieName)
         {
             string value;
-            if (UserFlags.TryGetValue(flag, out value))
+            if (UserCookies.TryGetValue(cookieName, out value))
             {
                 return value;
             }
-            return string.Empty;
+            return null;
         }
 
-
-        public string GetSessionFlag(string flag)
+        public string GetSessionCookie(string cookieName)
         {
             string value;
-            if (UserSessionFlags.TryGetValue(flag, out value))
+            if (UserSessionCookies.TryGetValue(cookieName, out value))
             {
                 return value;
             }
-            return string.Empty;
+            return null;
         }
+
+        public bool HasCookie(string cookieName) => UserCookies.Keys.Contains(cookieName);
+        public bool HasSessionCookie(string cookieName) => UserSessionCookies.Keys.Contains(cookieName);
+
+        public bool DeleteCookie(string cookieName) => UserCookies.Remove(cookieName);
+        public bool DeleteSessionCookie(string cookieName) => UserSessionCookies.Remove(cookieName);
+
 
         public override void UpdateAttributes(StatUpdateFlags flags)
         {

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -239,6 +239,16 @@ namespace Hybrasyl.Objects
             }
         }
 
+        public void ChrysalisMark()
+        {
+            // TODO: move to config
+            if (!Legend.TryGetMark("CHR", out LegendMark mark))
+            {
+                // Create initial mark of Deoch
+                Legend.AddMark(LegendIcon.Community, LegendColor.White, "Chaos Age Aisling", "CHR", true);
+            }
+        }
+
         public bool IsPrivileged
         {
             get
@@ -979,7 +989,7 @@ namespace Hybrasyl.Objects
                 var cache = World.DatastoreConnection.GetDatabase();
                 if (Statuses.Count == 0)
                     Statuses = CurrentStatusInfo;
-                cache.Set(GetStorageKey(Name), JsonConvert.SerializeObject(this, new JsonSerializerSettings() { PreserveReferencesHandling = PreserveReferencesHandling.All }));
+                cache.Set(GetStorageKey(Name), this);
             }
         }
 
@@ -1458,6 +1468,15 @@ namespace Hybrasyl.Objects
         public void SetSessionCookie(string cookieName, string value)
         {
             UserSessionCookies[cookieName] = value;
+        }
+
+        public IReadOnlyDictionary<string, string> GetCookies()
+        {
+            return UserCookies;
+        }
+        public IReadOnlyDictionary<string, string> GetSessionCookies()
+        {
+            return UserSessionCookies;
         }
 
         public string GetCookie(string cookieName)
@@ -2240,7 +2259,7 @@ namespace Hybrasyl.Objects
             //            profilePacket.WriteByte(1); // ??
             profilePacket.WriteByte(0);
             profilePacket.WriteByte(0); // ??
-            profilePacket.WriteString8(IsMaster ? "Master" : Hybrasyl.Constants.REVERSE_CLASSES[(int)Class]);
+            profilePacket.WriteString8(IsMaster ? "Master" : Hybrasyl.Constants.REVERSE_CLASSES[(int)Class].Capitalize());
             profilePacket.WriteString8(Guild.Name);
             profilePacket.WriteByte((byte)Legend.Count);
             foreach (var mark in Legend)

--- a/hybrasyl/Objects/WorldObject.cs
+++ b/hybrasyl/Objects/WorldObject.cs
@@ -111,7 +111,9 @@ namespace Hybrasyl.Objects
         public virtual void RegisterDialogSequence(DialogSequence sequence)
         {
             sequence.Id = (uint)(Constants.DIALOG_SEQUENCE_PURSUITS + DialogSequences.Count);
+            sequence.AssociateSequence(this);
             DialogSequences.Add(sequence);
+
             if (SequenceCatalog.ContainsKey(sequence.Name))
             {
                 Logger.WarnFormat("Dialog sequence {0} is being overwritten", sequence.Name);
@@ -119,6 +121,7 @@ namespace Hybrasyl.Objects
 
             }
             SequenceCatalog.Add(sequence.Name, sequence);
+            
         }
 
         public List<DialogSequence> Pursuits;

--- a/hybrasyl/Scripting/HybrasylDialog.cs
+++ b/hybrasyl/Scripting/HybrasylDialog.cs
@@ -31,6 +31,7 @@ namespace Hybrasyl.Scripting
     {
         internal Dialog Dialog { get; set; }
         internal DialogSequence Sequence { get; set; }
+        internal System.Type DialogType => Dialog.GetType();
 
         public HybrasylDialog(Dialog dialog)
         {
@@ -52,6 +53,13 @@ namespace Hybrasyl.Scripting
             Sequence = sequence;
             sequence.AddDialog(Dialog);
         }
+
+        public void AttachCallback(string luaExpr)
+        {
+            Dialog.CallbackExpression = luaExpr;
+        }
+
+
 
     }
 }

--- a/hybrasyl/Scripting/HybrasylUser.cs
+++ b/hybrasyl/Scripting/HybrasylUser.cs
@@ -55,6 +55,8 @@ namespace Hybrasyl.Scripting
             }
         }
 
+        public int Level { get => User.Stats.Level; }
+
         public uint Mp
         {
             get { return User.Stats.Mp; }
@@ -114,16 +116,20 @@ namespace Hybrasyl.Scripting
             return User.Legend;
         }
 
-        public bool AddLegendMark(LegendIcon icon, LegendColor color, string text, string prefix=default(string), bool isPublic = true, int quantity = 0)
+        public bool AddLegendMark(LegendIcon icon, LegendColor color, string text, string prefix=default(string), bool isPublic = true, 
+            int quantity = 0, bool displaySeason=true, bool displayTimestamp=true)
         {
-            return AddLegendMark(icon, color, text, DateTime.Now, prefix, isPublic, quantity);
+            return AddLegendMark(icon, color, text, DateTime.Now, prefix, isPublic, quantity, displaySeason, displayTimestamp);
         }
 
-        public bool AddLegendMark(LegendIcon icon, LegendColor color, string text, DateTime created, string prefix = default(string), bool isPublic = true, int quantity = 0)
+        public bool AddLegendMark(LegendIcon icon, LegendColor color, string text, HybrasylTime timestamp, string prefix) => User.Legend.AddMark(icon, color, text, timestamp.TerranDateTime, prefix);
+
+        public bool AddLegendMark(LegendIcon icon, LegendColor color, string text, DateTime timestamp, string prefix = default(string), 
+            bool isPublic = true, int quantity = 0, bool displaySeason=true, bool displayTimestamp=true)
         {
             try
             {
-                return User.Legend.AddMark(icon, color, text, created, prefix, isPublic, quantity);
+                return User.Legend.AddMark(icon, color, text, timestamp, prefix, isPublic, quantity, displaySeason, displayTimestamp);
             }
             catch (ArgumentException)
             {
@@ -167,7 +173,7 @@ namespace Hybrasyl.Scripting
             try
             {
                 if (value.GetType() == typeof(string))
-                    User.SetSessionCookie(cookieName, value);
+                    User.SetCookie(cookieName, value);
                 else
                     User.SetCookie(cookieName, value.ToString());
                 Logger.DebugFormat("{0} - set cookie {1} to {2}", User.Name, cookieName, value);
@@ -268,6 +274,8 @@ namespace Hybrasyl.Scripting
 
         public bool TakeExperience(int exp)
         {
+            if ((uint)exp > User.Stats.Experience)
+                return false;
             User.Stats.Experience -= (uint)exp;
             SystemMessage($"Your world spins as your insight leaves you ((-{exp} experience!))");
             User.UpdateAttributes(StatUpdateFlags.Experience);

--- a/hybrasyl/Scripting/HybrasylWorld.cs
+++ b/hybrasyl/Scripting/HybrasylWorld.cs
@@ -74,16 +74,13 @@ namespace Hybrasyl.Scripting
         }
 
         public int CurrentInGameYear => HybrasylTime.CurrentYear;
-        public string CurrentInGameAge => HybrasylTime.CurrentAge;
+        public string CurrentInGameAge => HybrasylTime.CurrentAgeName;
 
-        public string InGameTimeFromDelta(int years=0, int months=0, int days=0)
+        public HybrasylTime CurrentTime()
         {
-            var now = DateTime.Now;
-            var elapsed = new TimeSpan(years * 365 + months * 30 + days, 0, 0, 0);
-            var ht = HybrasylTime.ConvertToHybrasyl(now - elapsed);
-            return $"{ht.Age} {ht.Year}";
+            var ht = HybrasylTime.Now;
+            return ht;
         }
-
 
         public HybrasylDialogOptions NewDialogOptions() => new HybrasylDialogOptions();
 

--- a/hybrasyl/Scripting/HybrasylWorldObject.cs
+++ b/hybrasyl/Scripting/HybrasylWorldObject.cs
@@ -22,6 +22,7 @@
 
 
 using Hybrasyl.Objects;
+using log4net;
 using MoonSharp.Interpreter;
 
 namespace Hybrasyl.Scripting
@@ -30,6 +31,10 @@ namespace Hybrasyl.Scripting
     public class HybrasylWorldObject
     {
         internal WorldObject Obj { get; set; }
+
+        private static readonly ILog Logger = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly ILog ScriptingLogger = LogManager.GetLogger("ScriptingLog");
+
 
         public string Name
         {
@@ -78,21 +83,21 @@ namespace Hybrasyl.Scripting
                 var vobj = Obj as VisibleObject;
                 vobj.AddPursuit(hybrasylSequence.Sequence);
             }
-
         }
+
 
         public void RegisterSequence(HybrasylDialogSequence hybrasylSequence)
         {
+            if (hybrasylSequence is null)
+            {
+                ScriptingLogger.Error("RegisterSequence called with null/nil value. Check Lua");
+                return;       
+            }
             if (Obj is VisibleObject && !(Obj is User))
             {
                 var vobj = Obj as VisibleObject;
                 vobj.RegisterDialogSequence(hybrasylSequence.Sequence);
             }
-        }
-
-        public void RegisterGlobalSequence(HybrasylDialogSequence globalSequence)
-        {
-            Game.World.RegisterGlobalSequence(globalSequence.Sequence);
         }
 
         /// <summary>

--- a/hybrasyl/Scripting/ScriptProcessor.cs
+++ b/hybrasyl/Scripting/ScriptProcessor.cs
@@ -21,7 +21,9 @@
  */
  
 using System.Collections.Generic;
+using Hybrasyl.Enums;
 using log4net;
+using MoonSharp.Interpreter;
 
 namespace Hybrasyl.Scripting
 {
@@ -37,6 +39,11 @@ namespace Hybrasyl.Scripting
         {
             Scripts = new Dictionary<string, Script>();
             World = new HybrasylWorld(world);
+            // Register UserData types for MoonScript
+            UserData.RegisterAssembly();
+            UserData.RegisterType<Sex>();
+            UserData.RegisterType<LegendIcon>();
+            UserData.RegisterType<LegendColor>();
         }
 
         public bool TryGetScript(string scriptName, out Script script)

--- a/hybrasyl/Scripting/ScriptProcessor.cs
+++ b/hybrasyl/Scripting/ScriptProcessor.cs
@@ -19,7 +19,8 @@
  * For contributors and individual authors please refer to CONTRIBUTORS.MD.
  * 
  */
- 
+
+using System;
 using System.Collections.Generic;
 using Hybrasyl.Enums;
 using log4net;
@@ -44,6 +45,10 @@ namespace Hybrasyl.Scripting
             UserData.RegisterType<Sex>();
             UserData.RegisterType<LegendIcon>();
             UserData.RegisterType<LegendColor>();
+            UserData.RegisterType<LegendMark>();
+            UserData.RegisterType<DateTime>();
+            UserData.RegisterType<TimeSpan>();
+            
         }
 
         public bool TryGetScript(string scriptName, out Script script)

--- a/hybrasyl/Utility.cs
+++ b/hybrasyl/Utility.cs
@@ -256,6 +256,7 @@ namespace Hybrasyl
         public const int SIMPLE_DIALOG = 0;
         public const int OPTIONS_DIALOG = 2;
         public const int INPUT_DIALOG = 4;
+        public const int JUMP_DIALOG = 8;
     }
 
     static class MessageTypes


### PR DESCRIPTION
## Description
PR adding functionality related to Mileth scripting

## Related PRs
n/a

## Checklist
- [x] Tested and working locally
- [ ] Reviewed
- [ ] Tested and working on dev server
- [ ] Deployed to staging

## How to QA
Use `mileth-scripting` branch from `world`, note that Riona works completely

## Impacted Areas in Hybrasyl
* Adds `/reloadnpc` command, can be used to reload NPC scripts

* Adds `/showcookies`, `/deletecookies`, `/deletesessioncookies` commands (cookies are small fragments of session-based or permanent data that can be used by scripts to set state)

* Implements handling of Lua callbacks for text/option dialogs

* Implements `FunctionDialog`, a type of dialog that can be used to run independent Lua code in between two displayed dialogs, and `JumpDialog`, a dialog that will jump to another registered dialog or dialog sequence

* Extend time handling and simplify implementation; verify multiple ages (Danaan / Deoch) work as expected

* Implement additional Lua harnessing / framework as needed

This PR will probably be followed with more PRs as I continue to work on Mileth NPCs.

