### PR TITLE
Scripting updates & fixes roundup - August 2019

### DIFF
--- a/XML/XSD/hybrasylExtensions.cs
+++ b/XML/XSD/hybrasylExtensions.cs
@@ -30,7 +30,7 @@ namespace Hybrasyl.Items
 {
     public partial class Item
     {
-        public static SHA1 sha = new SHA1CryptoServiceProvider();
+        public static SHA256CryptoServiceProvider sha = new SHA256CryptoServiceProvider();
         [XmlIgnore]
         public bool IsVariant { get; set; }
 

--- a/XML/XSD/hybrasylExtensions.cs
+++ b/XML/XSD/hybrasylExtensions.cs
@@ -23,11 +23,14 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Xml.Serialization;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Hybrasyl.Items
 {
     public partial class Item
     {
+        public static SHA1 sha = new SHA1CryptoServiceProvider();
         [XmlIgnore]
         public bool IsVariant { get; set; }
 
@@ -128,14 +131,13 @@ namespace Hybrasyl.Items
         [XmlIgnore]
         public Dictionary<int, Item> Variants { get; set; }
 
-        public int Id
+        public string Id
         {
             get
             {
-                unchecked
-                {
-                    return 31 * Name.GetHashCode() * ((Properties.Restrictions?.Gender.GetHashCode() ?? Gender.Neutral.GetHashCode()) + 1);
-                }
+                var rawhash = $"{Name.Normalize()}:{Properties.Restrictions?.Gender.ToString().Normalize() ?? Gender.Neutral.ToString().Normalize()}";
+                var hash = sha.ComputeHash(Encoding.ASCII.GetBytes(rawhash));
+                return string.Concat(hash.Select(b => b.ToString("x2"))).Substring(0, 8);
             }
         }
 

--- a/hybrasyl/Inventory.cs
+++ b/hybrasyl/Inventory.cs
@@ -422,7 +422,7 @@ namespace Hybrasyl
         private object _lock = new object();
 
         private Lockable<ItemObject[]> _itemsObject;
-        private ConcurrentDictionary<int, List<ItemObject>> _inventoryIndex;
+        private ConcurrentDictionary<string, List<ItemObject>> _inventoryIndex;
 
         public static readonly ILog Logger = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
@@ -608,7 +608,7 @@ namespace Hybrasyl
             }
         }
 
-        public bool TryGetValue(string name, out ItemObject itemObject)
+        public bool TryGetValueByName(string name, out ItemObject itemObject)
         {
             itemObject = null;
             List<ItemObject> itemList;
@@ -619,7 +619,7 @@ namespace Hybrasyl
             return true;
         }
 
-        public bool TryGetValue(int templateId, out ItemObject itemObject)
+        public bool TryGetValue(string templateId, out ItemObject itemObject)
         {
             itemObject = null;
             List<ItemObject> itemList;
@@ -634,15 +634,15 @@ namespace Hybrasyl
             _size = new Lockable<int>(size);
             _count = new Lockable<int>(0);
             _weight = new Lockable<int>(0);
-            _inventoryIndex = new ConcurrentDictionary<int, List<ItemObject>>();
+            _inventoryIndex = new ConcurrentDictionary<string, List<ItemObject>>();
         }
 
-        public bool Contains(int id)
+        public bool Contains(string id)
         {
             return _inventoryIndex.ContainsKey(id);
         }
 
-        public bool Contains(string name)
+        public bool ContainsName(string name)
         {
             Item theItem = Game.World.WorldData.GetByIndex<Item>(name);
             return _inventoryIndex.ContainsKey(theItem.Id);
@@ -682,7 +682,7 @@ namespace Hybrasyl
             return (byte)(FindEmptyIndex() + 1);
         }
 
-        public int IndexOf(int id)
+        public int IndexOf(string id)
         {
             for (var i = 0; i < Size; ++i)
             {
@@ -692,7 +692,7 @@ namespace Hybrasyl
             return -1;
         }
 
-        public int[] IndexOf(string name)
+        public int[] IndexByName(string name)
         {
             var indices = new List<int>();
             for (var i = 0; i < Size; i++)
@@ -703,13 +703,13 @@ namespace Hybrasyl
             return indices.ToArray();
         }
 
-        public byte SlotOf(int id)
+        public byte SlotOf(string id)
         {
             return (byte)(IndexOf(id) + 1);
         }
-        public byte[] SlotOf(string name)
+        public byte[] SlotByName(string name)
         {
-            var slotsInt = IndexOf(name);
+            var slotsInt = IndexByName(name);
             var slotsByte = new byte[slotsInt.Length];
             for(int i = 0; i < slotsInt.Length; i++)
             {
@@ -718,12 +718,12 @@ namespace Hybrasyl
             return slotsByte;
         }
 
-        public ItemObject Find(int id)
+        public ItemObject Find(string id)
         {
             return _inventoryIndex.ContainsKey(id) ? _inventoryIndex[id].First() : null;
         }
 
-        public ItemObject Find(string name)
+        public ItemObject FindByName(string name)
         {
             Item theItem;
             return Game.World.TryGetItemTemplate(name, out theItem) && _inventoryIndex.ContainsKey(theItem.Id)

--- a/hybrasyl/Map.cs
+++ b/hybrasyl/Map.cs
@@ -296,7 +296,7 @@ namespace Hybrasyl
             Load();
         }
     
-
+        
         public Map()
         {
             Init();

--- a/hybrasyl/Map.cs
+++ b/hybrasyl/Map.cs
@@ -276,6 +276,7 @@ namespace Hybrasyl
                 var reactor = new Reactor(reactorElement.X, reactorElement.Y, this, 
                     reactorElement.Script, reactorElement.Description, reactorElement.Blocking);
                 InsertReactor(reactor);
+                Logger.Info($"{reactor.Id} placed in {reactor.Map.Name}, description was {reactor.Description}");
             }
             if (newMap.Signs != null) {
                 foreach (var postElement in newMap.Signs.Signposts)

--- a/hybrasyl/Monolith.cs
+++ b/hybrasyl/Monolith.cs
@@ -343,6 +343,7 @@ namespace Hybrasyl
         {
             while (true)
             {
+                // Ignore processing if no one is logged in, what's the point
                 var mapsWithUsers = _maps.Where(x => x.Users.Count() > 0);
                 foreach (var map in mapsWithUsers)
                 {                   

--- a/hybrasyl/Objects/Creature.cs
+++ b/hybrasyl/Objects/Creature.cs
@@ -714,7 +714,7 @@ namespace Hybrasyl.Objects
             Direction = direction;
 
             // Objects in the common viewport receive a "walk" (0x0C) packet
-            // Objects in the arriving viewport receive a "show to" (_) packet
+            // Objects in the arriving viewport receive a "show to" (0x33) packet
             // Objects in the departing viewport receive a "remove object" (0x0E) packet
 
             foreach (var obj in Map.EntityTree.GetObjects(commonViewport))

--- a/hybrasyl/Objects/Creature.cs
+++ b/hybrasyl/Objects/Creature.cs
@@ -714,7 +714,7 @@ namespace Hybrasyl.Objects
             Direction = direction;
 
             // Objects in the common viewport receive a "walk" (0x0C) packet
-            // Objects in the arriving viewport receive a "show to" (0x33) packet
+            // Objects in the arriving viewport receive a "show to" (_) packet
             // Objects in the departing viewport receive a "remove object" (0x0E) packet
 
             foreach (var obj in Map.EntityTree.GetObjects(commonViewport))

--- a/hybrasyl/Objects/ItemObject.cs
+++ b/hybrasyl/Objects/ItemObject.cs
@@ -31,7 +31,7 @@ namespace Hybrasyl.Objects
 {
     public class ItemObject : VisibleObject
     {
-        public int TemplateId { get; private set; }
+        public string TemplateId { get; private set; }
 
         /// <summary>
         /// Check to see if a specified user can equip an ItemObject. Returns a boolean indicating whether
@@ -273,7 +273,7 @@ namespace Hybrasyl.Objects
             }
         }
 
-        public ItemObject(int id, World world)
+        public ItemObject(string id, World world)
         {
             World = world;
             TemplateId = id;

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -1969,7 +1969,7 @@ namespace Hybrasyl.Objects
                 // Merge stack and destroy "added" ItemObject
                 inventoryItem.Count += itemObject.Count;
                 itemObject.Count = 0;
-                SendItemUpdate(inventoryItem, Inventory.SlotOf(inventoryItem.Name).First());
+                SendItemUpdate(inventoryItem, Inventory.SlotByName(inventoryItem.Name).First());
                 World.Remove(itemObject);
                 return true;
             }
@@ -2006,7 +2006,7 @@ namespace Hybrasyl.Objects
             if (Inventory.Contains(itemName, quantity))
             {
                 var remaining = (int)quantity;
-                var slots = Inventory.SlotOf(itemName);
+                var slots = Inventory.SlotByName(itemName);
                 foreach (var i in slots)
                 {
                     if (remaining > 0)
@@ -3130,7 +3130,7 @@ namespace Hybrasyl.Objects
                 var hasItem = Inventory.Contains(itemObj.Name);
                 if (hasItem)
                 {
-                    if (itemObj.Stackable) IncreaseItem(Inventory.SlotOf(itemObj.Name).First(), quantity);
+                    if (itemObj.Stackable) IncreaseItem(Inventory.SlotByName(itemObj.Name).First(), quantity);
                     else
                     {
                         AddItem(itemObj);
@@ -3141,7 +3141,7 @@ namespace Hybrasyl.Objects
                     if (itemObj.Stackable)
                     {
                         AddItem(itemObj);
-                        IncreaseItem(Inventory.SlotOf(itemObj.Name).First(), quantity - 1);
+                        IncreaseItem(Inventory.SlotByName(itemObj.Name).First(), quantity - 1);
                     }
                     else
                     {

--- a/hybrasyl/Scripting/HybrasylUser.cs
+++ b/hybrasyl/Scripting/HybrasylUser.cs
@@ -328,10 +328,10 @@ namespace Hybrasyl.Scripting
             DialogSequence newSequence;
             if (User.World.GlobalSequencesCatalog.TryGetValue(sequenceName, out newSequence))
             {
-                newSequence.ShowTo(User, (VisibleObject)associate.Obj);
                 // End previous sequence
                 User.DialogState.EndDialog();
                 User.DialogState.StartDialog(associate.Obj as VisibleObject, newSequence);
+                newSequence.ShowTo(User, (VisibleObject)associate.Obj);
             }
 
         }

--- a/hybrasyl/Scripting/ScriptProcessor.cs
+++ b/hybrasyl/Scripting/ScriptProcessor.cs
@@ -53,7 +53,7 @@ namespace Hybrasyl.Scripting
         }
 
         // "Ri OnA.lua" => riona
-        private string SanitizeName(string scriptName) => Regex.Replace(scriptName.ToLower().Normalize(), ".lua$", "")
+        private string SanitizeName(string scriptName) => Regex.Replace(scriptName.ToLower().Normalize(), ".lua$", "");
 
         private bool TryGetScriptInstances(string scriptName, out List<Script> scriptList)
         {

--- a/hybrasyl/Scripting/ScriptProcessor.cs
+++ b/hybrasyl/Scripting/ScriptProcessor.cs
@@ -52,13 +52,13 @@ namespace Hybrasyl.Scripting
             _scripts = new Dictionary<string, List<Script>>();            
         }
 
+        // "Ri OnA.lua" => riona
+        private string SanitizeName(string scriptName) => Regex.Replace(scriptName.ToLower(), ".lua$", "").Replace(@"\s+", "");
+
         private bool TryGetScriptInstances(string scriptName, out List<Script> scriptList)
         {
-            if (_scripts.TryGetValue(scriptName, out scriptList))
-            {
-                return true;
-            }
-            else if (_scripts.TryGetValue($"{scriptName}.lua", out scriptList))
+            scriptList = null;
+            if (_scripts.TryGetValue(SanitizeName(scriptName), out scriptList))
             {
                 return true;
             }
@@ -70,11 +70,10 @@ namespace Hybrasyl.Scripting
             script = null;
             // Note that a request for RiOnA.lua == Riona == riona as long as
             // riona exists
-            var target = scriptName.ToLower();
-            target = Regex.Replace(target, ".lua$", "");
-            if (TryGetScriptInstances(scriptName, out List<Script> s))
+            if (TryGetScriptInstances(SanitizeName(scriptName), out List<Script> s))
             {
                 script = s[0].Clone();
+                return true;
             }
             return false;
         }
@@ -82,18 +81,17 @@ namespace Hybrasyl.Scripting
         public void RegisterScript(Script script)
         {
             script.Run();
-            if (!_scripts.ContainsKey(script.Name))
+            var target = SanitizeName(script.Name);
+            if (!TryGetScriptInstances(target, out List<Script> scriptList))
             {
-                _scripts[script.Name] = new List<Script>();
+                _scripts[target] = new List<Script>();
             }
-            _scripts[script.Name].Add(script);
+            _scripts[target].Add(script);
         }
 
         public bool Reload(string scriptName)
         {
-            var target = scriptName.ToLower();
-            target = Regex.Replace(target, ".lua$", "");
-            if (TryGetScriptInstances(target, out List<Script> s))
+            if (TryGetScriptInstances(SanitizeName(scriptName), out List<Script> s))
             {
                 foreach (var instance in s)
                 {

--- a/hybrasyl/Scripting/ScriptProcessor.cs
+++ b/hybrasyl/Scripting/ScriptProcessor.cs
@@ -53,7 +53,7 @@ namespace Hybrasyl.Scripting
         }
 
         // "Ri OnA.lua" => riona
-        private string SanitizeName(string scriptName) => Regex.Replace(scriptName.ToLower(), ".lua$", "").Replace(@"\s+", "");
+        private string SanitizeName(string scriptName) => Regex.Replace(scriptName.ToLower().Normalize(), ".lua$", "")
 
         private bool TryGetScriptInstances(string scriptName, out List<Script> scriptList)
         {

--- a/hybrasyl/Scripting/ScriptProcessor.cs
+++ b/hybrasyl/Scripting/ScriptProcessor.cs
@@ -35,12 +35,11 @@ namespace Hybrasyl.Scripting
         public static readonly ILog Logger = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         private static readonly ILog ScriptingLogger = LogManager.GetLogger(Assembly.GetEntryAssembly(),"ScriptingLog");
 
-        public Dictionary<string, Script> Scripts { get; private set; }
         public HybrasylWorld World { get; private set; }
+        public Dictionary<string, List<Script>> _scripts { get; private set; }
 
         public ScriptProcessor(World world)
         {
-            Scripts = new Dictionary<string, Script>();
             World = new HybrasylWorld(world);
             // Register UserData types for MoonScript
             UserData.RegisterAssembly(typeof(Game).Assembly);
@@ -50,7 +49,20 @@ namespace Hybrasyl.Scripting
             UserData.RegisterType<LegendMark>();
             UserData.RegisterType<DateTime>();
             UserData.RegisterType<TimeSpan>();
-            
+            _scripts = new Dictionary<string, List<Script>>();            
+        }
+
+        private bool TryGetScriptInstances(string scriptName, out List<Script> scriptList)
+        {
+            if (_scripts.TryGetValue(scriptName, out scriptList))
+            {
+                return true;
+            }
+            else if (_scripts.TryGetValue($"{scriptName}.lua", out scriptList))
+            {
+                return true;
+            }
+            return false;
         }
 
         public bool TryGetScript(string scriptName, out Script script)
@@ -60,25 +72,37 @@ namespace Hybrasyl.Scripting
             // riona exists
             var target = scriptName.ToLower();
             target = Regex.Replace(target, ".lua$", "");
-            if (Scripts.TryGetValue(target, out script))
-                return true;
-            else if (Scripts.TryGetValue($"{target}.lua", out script))
-                return true;
-
-            return false;               
+            if (TryGetScriptInstances(scriptName, out List<Script> s))
+            {
+                script = s[0].Clone();
+            }
+            return false;
         }
 
-        public bool RegisterScript(Script script)
+        public void RegisterScript(Script script)
         {
             script.Run();
-            Scripts[script.Name] = script;
-            return true;
+            if (!_scripts.ContainsKey(script.Name))
+            {
+                _scripts[script.Name] = new List<Script>();
+            }
+            _scripts[script.Name].Add(script);
         }
 
-        public bool DeregisterScript(string scriptname)
+        public bool Reload(string scriptName)
         {
-            Scripts[scriptname] = null;
-            return true;
+            var target = scriptName.ToLower();
+            target = Regex.Replace(target, ".lua$", "");
+            if (TryGetScriptInstances(target, out List<Script> s))
+            {
+                foreach (var instance in s)
+                {
+                    instance.Reload();
+                    Logger.Info($"Reloading instance of {scriptName}: associate was {instance.Associate?.Name ?? "None"}");
+                }
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/hybrasyl/Utility.cs
+++ b/hybrasyl/Utility.cs
@@ -402,6 +402,8 @@ namespace Hybrasyl
                 a[0] = char.ToUpper(a[0]);
                 return new string(a);
             }
+            public static string Normalize(string key) => Regex.Replace(key.ToLower(), @"\s+", "");
+
         }
 
     } // end Namespace:Utility

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -1679,11 +1679,17 @@ namespace Hybrasyl
             }
             else if (loginUser.Login.FirstLogin)
             {
-                StartMap startmap = Game.Config.Handlers.NewPlayer.GetStartMap();
-                loginUser.Login.FirstLogin = false;
-                if (WorldData.TryGetValueByIndex(startmap.Value, out Map map))
-                    loginUser.Teleport(map.Id, startmap.X, startmap.Y);
-                else loginUser.Teleport((ushort)500, (byte)50, (byte)(50));
+                NewPlayer handler = Game.Config.Handlers?.NewPlayer;
+                if (handler != null)
+                {
+                    StartMap startmap = handler.GetStartMap();
+                    loginUser.Login.FirstLogin = false;
+                    if (WorldData.TryGetValueByIndex(startmap.Value, out Map map))
+                        loginUser.Teleport(map.Id, startmap.X, startmap.Y);
+                    else loginUser.Teleport((ushort)500, (byte)50, (byte)(50));
+                }
+                // Fall back to defaults if config doesn't exist
+                loginUser.Teleport((ushort)500, (byte)50, (byte)50);
             }
             else if(loginUser.Nation.SpawnPoints.Count != 0 &&
                 loginUser.SinceLastLogin > Hybrasyl.Constants.NATION_SPAWN_TIMEOUT)

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -3617,7 +3617,7 @@ namespace Hybrasyl
             obj.Id = 0;
         }
 
-        public ItemObject CreateItem(int id, int quantity = 1)
+        public ItemObject CreateItem(string id, int quantity = 1)
         {
             if (WorldData.ContainsKey<Item>(id))
             {

--- a/hybrasyl/WorldDataStore.cs
+++ b/hybrasyl/WorldDataStore.cs
@@ -4,6 +4,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Hybrasyl.Utility;
 
 namespace Hybrasyl
 {
@@ -20,7 +21,6 @@ namespace Hybrasyl
         /// </summary>
         /// <param name="key">Dynamic key object, which must provide a ToString</param>
         /// <returns>A normalized string</returns>
-        private string NormalizeKey(dynamic key) => Regex.Replace(key.ToString().ToLower(), @"\s+", "");
 
         /// <summary>
         /// Constructor, takes no arguments.
@@ -71,7 +71,7 @@ namespace Hybrasyl
         {
             if (_dataStore.ContainsKey(typeof(T)))
             {
-                return (T) _dataStore[typeof(T)][NormalizeKey(key)];
+                return (T) _dataStore[typeof(T)][key.ToString().Normalize()];
             }
             return default(T);
         }
@@ -96,7 +96,7 @@ namespace Hybrasyl
         {
             if (_index.ContainsKey(typeof(T)))
             {
-                return (T) _index[typeof(T)][NormalizeKey(key)];
+                return (T) _index[typeof(T)][key.ToString.Normalize()];
             }
             return default(T);
         }
@@ -112,8 +112,8 @@ namespace Hybrasyl
         {
             tresult = default(T);
             var sub = GetSubStore<T>();
-            if (!sub.ContainsKey(NormalizeKey(key))) return false;
-            tresult = (T) sub[NormalizeKey(key)];
+            if (!sub.ContainsKey(key.ToString().Normalize())) return false;
+            tresult = (T) sub[key.ToString().Normalize()];
             return true;
         }
 
@@ -128,12 +128,12 @@ namespace Hybrasyl
         {
             tresult = default(T);
             var sub = GetSubIndex<T>();
-            if (!sub.ContainsKey(NormalizeKey(key)))
+            if (!sub.ContainsKey(key.ToString().Normalize()))
             {
-                Logger.Error($"TryGetValueByIndex: type {typeof(T)}: key {NormalizeKey(key)} not found");
+                Logger.Error($"TryGetValueByIndex: type {typeof(T)}: key {key.ToString().Normalize()} not found");
                 return false;
             }
-            tresult = (T)sub[NormalizeKey(key)];
+            tresult = (T)sub[key.ToString().Normalize()];
             return true;
         }
 
@@ -144,7 +144,7 @@ namespace Hybrasyl
         /// <param name="key">The key to be used for the object</param>
         /// <param name="value">The actual object to be stored</param>
         /// <returns>Boolean indicating success</returns>
-        public bool Set<T>(dynamic key, T value) => GetSubStore<T>().TryAdd(NormalizeKey(key), value);
+        public bool Set<T>(dynamic key, T value) => GetSubStore<T>().TryAdd(key.ToString().Normalize(), value);
 
         /// <summary>
         /// Store an object in the datastore with the given key and index key.
@@ -154,7 +154,7 @@ namespace Hybrasyl
         /// <param name="value">The actual object to be stored</param>
         /// <param name="index">The index key for the object</param>
         /// <returns>Boolean indicating success</returns>
-        public bool SetWithIndex<T>(dynamic key, T value, dynamic index) => GetSubStore<T>().TryAdd(NormalizeKey(key), value) && GetSubIndex<T>().TryAdd(NormalizeKey(index), value);
+        public bool SetWithIndex<T>(dynamic key, T value, dynamic index) => GetSubStore<T>().TryAdd(key.ToString().Normalize(), value) && GetSubIndex<T>().TryAdd(index.ToString().Normalize(), value);
    
 
         /// <summary>
@@ -177,7 +177,7 @@ namespace Hybrasyl
         /// <typeparam name="T">The type to check</typeparam>
         /// <param name="key">The key to check</param>
         /// <returns>Boolean indicating whether or not the key exists</returns>
-        public bool ContainsKey<T>(dynamic key) => GetSubStore<T>().ContainsKey(NormalizeKey(key));
+        public bool ContainsKey<T>(dynamic key) => GetSubStore<T>().ContainsKey(key.ToString().Normalize());
 
         /// <summary>
         /// Return a count of typed objects in the datastore.
@@ -202,7 +202,7 @@ namespace Hybrasyl
         public bool Remove<T>(dynamic key)
         {
             dynamic ignored;
-            return GetSubStore<T>().TryRemove(NormalizeKey(key), out ignored);
+            return GetSubStore<T>().TryRemove(key.ToString().Normalize(), out ignored);
         }
 
     }

--- a/hybrasyl/WorldDataStore.cs
+++ b/hybrasyl/WorldDataStore.cs
@@ -1,7 +1,9 @@
-﻿using System;
+﻿using log4net;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Hybrasyl
 {
@@ -9,6 +11,16 @@ namespace Hybrasyl
     {
         private ConcurrentDictionary<Type, ConcurrentDictionary<string, dynamic>> _dataStore;
         private ConcurrentDictionary<Type, ConcurrentDictionary<dynamic, dynamic>> _index;
+        public static readonly ILog Logger = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        /// <summary>
+        /// Normalize keys by converting to lowercase and removing whitespace (this means that 
+        /// MiLeTh InN RoOm 1 => milethinnroom1. Collisions are possible here if you are mixing case in
+        /// keys, in which case, I suggest you ask yourself why you're doing that.
+        /// </summary>
+        /// <param name="key">Dynamic key object, which must provide a ToString</param>
+        /// <returns>A normalized string</returns>
+        private string NormalizeKey(dynamic key) => Regex.Replace(key.ToString().ToLower(), @"\s+", "");
 
         /// <summary>
         /// Constructor, takes no arguments.
@@ -59,10 +71,18 @@ namespace Hybrasyl
         {
             if (_dataStore.ContainsKey(typeof(T)))
             {
-                return (T) _dataStore[typeof(T)][key.ToString().ToLower()];
+                return (T) _dataStore[typeof(T)][NormalizeKey(key)];
             }
             return default(T);
         }
+
+        /// <summary>
+        /// Return the first of any known type (e.g. first map, first NPC, etc)
+        /// </summary>
+        /// <typeparam name="T">The type of the object desired</typeparam>
+        /// <returns></returns>
+
+        public T First<T>() => (T)_dataStore[typeof(T)].First().Value;
 
         /// <summary>
         /// Given a type and a key, return the typed object matching the key in the subindex,
@@ -76,7 +96,7 @@ namespace Hybrasyl
         {
             if (_index.ContainsKey(typeof(T)))
             {
-                return (T) _index[typeof(T)][key];
+                return (T) _index[typeof(T)][NormalizeKey(key)];
             }
             return default(T);
         }
@@ -92,8 +112,8 @@ namespace Hybrasyl
         {
             tresult = default(T);
             var sub = GetSubStore<T>();
-            if (!sub.ContainsKey(key.ToString().ToLower())) return false;
-            tresult = (T) sub[key.ToString().ToLower()];
+            if (!sub.ContainsKey(NormalizeKey(key))) return false;
+            tresult = (T) sub[NormalizeKey(key)];
             return true;
         }
 
@@ -108,8 +128,12 @@ namespace Hybrasyl
         {
             tresult = default(T);
             var sub = GetSubIndex<T>();
-            if (!sub.ContainsKey(key)) return false;
-            tresult = (T)sub[key];
+            if (!sub.ContainsKey(NormalizeKey(key)))
+            {
+                Logger.Error($"TryGetValueByIndex: type {typeof(T)}: key {NormalizeKey(key)} not found");
+                return false;
+            }
+            tresult = (T)sub[NormalizeKey(key)];
             return true;
         }
 
@@ -120,7 +144,7 @@ namespace Hybrasyl
         /// <param name="key">The key to be used for the object</param>
         /// <param name="value">The actual object to be stored</param>
         /// <returns>Boolean indicating success</returns>
-        public bool Set<T>(dynamic key, T value) => GetSubStore<T>().TryAdd(key.ToString().ToLower(), value);
+        public bool Set<T>(dynamic key, T value) => GetSubStore<T>().TryAdd(NormalizeKey(key), value);
 
         /// <summary>
         /// Store an object in the datastore with the given key and index key.
@@ -130,7 +154,7 @@ namespace Hybrasyl
         /// <param name="value">The actual object to be stored</param>
         /// <param name="index">The index key for the object</param>
         /// <returns>Boolean indicating success</returns>
-        public bool SetWithIndex<T>(dynamic key, T value, dynamic index) => GetSubStore<T>().TryAdd(key.ToString().ToLower(), value) && GetSubIndex<T>().TryAdd(index, value);
+        public bool SetWithIndex<T>(dynamic key, T value, dynamic index) => GetSubStore<T>().TryAdd(NormalizeKey(key), value) && GetSubIndex<T>().TryAdd(NormalizeKey(index), value);
    
 
         /// <summary>
@@ -153,7 +177,7 @@ namespace Hybrasyl
         /// <typeparam name="T">The type to check</typeparam>
         /// <param name="key">The key to check</param>
         /// <returns>Boolean indicating whether or not the key exists</returns>
-        public bool ContainsKey<T>(dynamic key) => GetSubStore<T>().ContainsKey(key.ToString().ToLower());
+        public bool ContainsKey<T>(dynamic key) => GetSubStore<T>().ContainsKey(NormalizeKey(key));
 
         /// <summary>
         /// Return a count of typed objects in the datastore.
@@ -178,7 +202,7 @@ namespace Hybrasyl
         public bool Remove<T>(dynamic key)
         {
             dynamic ignored;
-            return GetSubStore<T>().TryRemove(key, out ignored);
+            return GetSubStore<T>().TryRemove(NormalizeKey(key), out ignored);
         }
 
     }


### PR DESCRIPTION
## Description
This PR fixes a number of issues exposed by reusing global scripts / dialogs, and Mileth scripting more generally. The usage of shared global dialogs and reactor script reuse now works as expected.

## Related PRs
n/a

## Checklist
- [x] Tested and working locally
- [ ] Reviewed
- [ ] Tested and working on dev server
- [ ] Deployed to staging

## How to QA
1. Login
2. Use current world repo
3. Note that "wakeup scripts" work
4. Go downstairs
5. Note that all paths of Riona greeting work

## Impacted Areas in Hybrasyl
* `WorldDataStore` indexes and keys are now normalized: `ToLower()` and all whitespace removed.
* Script names are now normalized in a similar fashion (and `.lua` is removed).
* Items now use a short-SHA hash as an ID. No more of this weird unsigned / unchecked int shit.
* Bug with global dialog sequences not working fixed. They are now stored at the top (65535 and downwards) of the sequence space, rather than the bottom.
* Bug with shared sequences fixed by making each script an instance. Each reference to a global script is its own script object with its own settable associate.
* Improve handling of first login if `Handler` is missing in `config.xml`, also remove hardcoded defaults.
* `Normalize()` added to string extensions (thus the normalization above all uses one function, globally)

