### PR TITLE
Scripting API / dialog updates

### DIFF
--- a/hybrasyl/Inventory.cs
+++ b/hybrasyl/Inventory.cs
@@ -634,7 +634,7 @@ namespace Hybrasyl
             _weight = new Lockable<int>(0);
             _inventoryIndex = new ConcurrentDictionary<string, List<ItemObject>>();
         }
-
+        
         public bool Contains(string id)
         {
             return _inventoryIndex.ContainsKey(id);
@@ -642,29 +642,39 @@ namespace Hybrasyl
 
         public bool ContainsName(string name)
         {
-            Item theItem = Game.World.WorldData.GetByIndex<Item>(name);
-            return _inventoryIndex.ContainsKey(theItem.Id);
+            // TODO: revisit this later
+            var itemList = Game.World.WorldData.FindItem(name);
+            if (itemList.Count == 0)
+                return false;
+            foreach (var item in itemList)
+                if (_inventoryIndex.ContainsKey(item.Id))
+                    return true;
+            return false;
         }
 
         public bool Contains(string name, int quantity)
         {
-            Item theItem = Game.World.WorldData.GetByIndex<Item>(name); 
-            
-            var hasItem = _inventoryIndex.ContainsKey(theItem.Id);
-            if (!hasItem) return false;
-            var inv = _inventoryIndex.Where(x=> x.Key == theItem.Id).ToList();
+            var itemList = Game.World.WorldData.FindItem(name);
+            if (itemList.Count == 0)
+                return false;
 
-            var quant = 0;
-            foreach (var itm in inv)
+            foreach (var item in itemList)
             {
-                quant += itm.Value.Count;
+                if (!_inventoryIndex.ContainsKey(item.Id))
+                    continue;
+
+                var quant = 0;
+
+                foreach (var itm in _inventoryIndex.Where(x => x.Key == item.Id).ToList())
+                {
+                    quant += itm.Value.Count;
+                }
+                var hasQuantity = quant >= quantity;
+                if (quant >= quantity)
+                    return true;
             }
-
-            var hasQuantity = quant >= quantity;
-            return hasQuantity;
+            return false;
         }
-
-
 
         public int FindEmptyIndex()
         {

--- a/hybrasyl/Messaging/Admin.cs
+++ b/hybrasyl/Messaging/Admin.cs
@@ -20,7 +20,35 @@ namespace Hybrasyl.Messaging
         {
             if (Game.World.WorldData.TryGetValue<User>(args[0], out User target))
             {
-                return Success($"User {target.Name} Cookies\n\n{target.GetCookies()}\n\nSession Cookies\n\n{target.GetSessionCookies()}", MessageTypes.SLATE_WITH_SCROLLBAR);
+                string cookies = $"User {target.Name} Cookie List\n\n---Permanent Cookies---\n";
+                foreach (var cookie in target.GetCookies())
+                    cookies = $"{cookies}\n{cookie.Key} : {cookie.Value}\n";
+                cookies = $"{cookies}\n---Session Cookies---\n";
+                foreach (var cookie in target.GetSessionCookies())
+                    cookies = $"{cookies}\n{cookie.Key} : {cookie.Value}\n";
+                return Success($"{cookies}", MessageTypes.SLATE_WITH_SCROLLBAR);
+            }
+            return Fail($"User {args[0]} not logged in");
+        }
+    }
+
+    class ClearCookie : ChatCommand
+    {
+        public new static string Command = "clearcookie";
+        public new static string ArgumentText = "<string playername> <string cookie>";
+        public new static string HelpText = "Clear a given (permament) cookie for a specified player";
+        public new static bool Privileged = true;
+
+        public new static ChatCommandResult Run(User user, params string[] args)
+        {
+            if (Game.World.WorldData.TryGetValue<User>(args[0], out User target))
+            {
+                if (target.HasCookie(args[1]))
+                {
+                    target.DeleteCookie(args[1]);
+                    return Success($"User {target.Name}: cookie {args[1]} deleted");
+                }
+                else return Fail($"User {args[0]} doesn't have cookie {args[1]}");
             }
             return Fail($"User {args[0]} not logged in");
         }
@@ -335,6 +363,7 @@ namespace Hybrasyl.Messaging
                 {
                     script.Reload();
                     merchant.Ready = false; // Force reload next time NPC processes an interaction
+                    merchant.Say("...What? What happened?");
                     return Success($"NPC {args[0]} - script {script.Name} reloaded. Clicking should re-run OnSpawn.");
                 }
                 else return Fail("NPC found but script not found...?");

--- a/hybrasyl/Messaging/Admin.cs
+++ b/hybrasyl/Messaging/Admin.cs
@@ -54,6 +54,28 @@ namespace Hybrasyl.Messaging
         }
     }
 
+    class ClearSessionCookie : ChatCommand
+    {
+        public new static string Command = "clearsessioncookie";
+        public new static string ArgumentText = "<string playername> <string cookie>";
+        public new static string HelpText = "Clear a given session cookie for a specified player";
+        public new static bool Privileged = true;
+
+        public new static ChatCommandResult Run(User user, params string[] args)
+        {
+            if (Game.World.WorldData.TryGetValue<User>(args[0], out User target))
+            {
+                if (target.HasSessionCookie(args[1]))
+                {
+                    target.DeleteSessionCookie(args[1]);
+                    return Success($"User {target.Name}: session cookie {args[1]} deleted");
+                }
+                else return Fail($"User {args[0]} doesn't have session cookie {args[1]}");
+            }
+            return Fail($"User {args[0]} not logged in");
+        }
+    }
+
     class SummonCommand : ChatCommand
     {
         public new static string Command = "summon";

--- a/hybrasyl/Objects/WorldObject.cs
+++ b/hybrasyl/Objects/WorldObject.cs
@@ -29,6 +29,7 @@ using Hybrasyl.Dialogs;
 using Hybrasyl.Scripting;
 using Serilog;
 using Newtonsoft.Json;
+using System.Collections.Concurrent;
 
 namespace Hybrasyl.Objects
 {
@@ -53,10 +54,13 @@ namespace Hybrasyl.Objects
         public World World { get; set; }
         public ushort DialogSprite { get; set; }
 
+        public ConcurrentDictionary<string, dynamic> EphemeralStore { get; set; }
+
         public WorldObject()
         {
             Name = string.Empty;
             ResetPursuits();
+            EphemeralStore = new ConcurrentDictionary<string, dynamic>();
         }
 
         public virtual void SendId()

--- a/hybrasyl/Scripting/HybrasylDialogSequence.cs
+++ b/hybrasyl/Scripting/HybrasylDialogSequence.cs
@@ -31,10 +31,14 @@ namespace Hybrasyl.Scripting
     {
         internal DialogSequence Sequence { get; private set; }
         
-
         public HybrasylDialogSequence(string sequenceName, bool closeOnEnd = false)
         {
             Sequence = new DialogSequence(sequenceName, closeOnEnd);
+        }
+
+        internal HybrasylDialogSequence(DialogSequence sequence)
+        {
+            Sequence = sequence;
         }
 
         public void AddDialog(HybrasylDialog scriptDialog)

--- a/hybrasyl/Scripting/HybrasylUtility.cs
+++ b/hybrasyl/Scripting/HybrasylUtility.cs
@@ -1,0 +1,42 @@
+﻿/*
+ * This file is part of Project Hybrasyl.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the Affero General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * without ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2019 Justin Baugh (baughj@hybrasyl.com)
+ * (C) 2019 Project Hybrasyl (info@hybrasyl.com)
+ *
+ * Authors:   Justin Baugh  <baughj@hybrasyl.com>
+ */
+
+using MoonSharp.Interpreter;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hybrasyl.Scripting
+{
+    /// <summary>
+    /// A variety of utility functions for scripts that are statically accessible from a global `utility` object.
+    /// </summary>
+    
+    [MoonSharpUserData]
+    public static class HybrasylUtility
+    {
+        public static int GetCurrentHour() => DateTime.Now.Hour;
+        public static int GetCurrentDay() => DateTime.Now.Day;
+        public static long GetUnixTime() => new DateTimeOffset(DateTime.Now).ToUnixTimeSeconds();
+        public static long HoursBetweenUnixTimes(long t1, long t2) => ((t2 - t1) / 3600);
+        public static long HoursBetweenUnixTimes(string t1, string t2) => (Convert.ToInt64(t2) - Convert.ToInt64(t1)) / 3600;
+    }
+}

--- a/hybrasyl/Scripting/HybrasylWorld.cs
+++ b/hybrasyl/Scripting/HybrasylWorld.cs
@@ -40,10 +40,7 @@ namespace Hybrasyl.Scripting
             Options = new OrderedDictionary();
         }
 
-        public void AddOption(string option, string luaExpr=null)
-        {
-            Options.Add(option, luaExpr);
-        }
+        public void AddOption(string option, string luaExpr = null) => Options.Add(option, luaExpr);
 
         public void AddOption(string option, HybrasylDialog nextDialog)
         {
@@ -52,6 +49,8 @@ namespace Hybrasyl.Scripting
             else
                 GameLog.Error($"Dialog option {option}: unsupported dialog type {nextDialog.DialogType.Name}");
         }
+
+        public void AddOption(string option, HybrasylDialogSequence sequence) => Options.Add(option, sequence);
     }
 
     [MoonSharpUserData]
@@ -108,6 +107,73 @@ namespace Hybrasyl.Scripting
             return new HybrasylDialog(dialog);
         }
 
+        /// <summary>
+        /// Create a new dialog sequence consisting of a bunch of simple text dialogs.
+        /// </summary>
+        /// <param name="sequenceName">The name of the constructed sequence.</param>
+        /// <param name="textList">A string array of dialog lines that will be used to construct each dialog in the sequence.</param>
+        /// <returns>The constructed dialog seqeunce</returns>
+        public HybrasylDialogSequence NewSimpleDialogSequence(string sequenceName, params string[] textList)
+        {
+            var sequence = new DialogSequence(sequenceName);
+            foreach (var entry in textList)
+            {
+                sequence.AddDialog(new SimpleDialog(entry));
+            }
+            return new HybrasylDialogSequence(sequence);
+        }
+
+        /// <summary>
+        /// Create a new dialog sequence consisting of a simple dialog and a jump to a new sequence. Useful 
+        /// for a lot of dialogs where you need to display one dialog and go back to the main menu.
+        /// </summary>
+        /// <param name="simpleDialog">Text for the simple dialog.</param>
+        /// <param name="jumpTarget">The new sequence to start after the user hits next on the simple dialog.</param>
+        /// <param name="callback">An optional Lua callback expression that will be attached to the simple dialog.</param>
+        /// <param name="name">An optional name to give the dialog sequence.</param>
+        /// <returns>The constructed dialog sequence</returns>
+        public HybrasylDialogSequence NewTextAndJumpDialog(string simpleDialog, string jumpTarget, string callback = "", string name = null)
+        {
+            DialogSequence sequence;
+            if (name == null)
+                sequence = new DialogSequence(Guid.NewGuid().ToString());
+            else
+                sequence = new DialogSequence(name);
+            var dialog = new SimpleDialog(simpleDialog);
+
+            if (!string.IsNullOrEmpty(callback))
+                dialog.CallbackExpression = callback;
+
+            sequence.AddDialog(dialog);
+            sequence.AddDialog(new JumpDialog(jumpTarget));
+            return new HybrasylDialogSequence(sequence);
+        }
+
+        /// <summary>
+        /// Another convenience function to generate an "end" sequence where the user must hit close (e.g. a dialog end). 
+        /// This is useful to make a jumpable end to a previous dialog option.
+        /// </summary>
+        /// <param name="simpleDialog">The text of the simple dialog.</param>
+        /// <param name="callback">An optional Lua callback expression that will be attached to the simple dialog.</param>
+        /// <param name="name">An optional name to give the dialog sequence.</param>
+        /// <returns>The constructed dialog sequence</returns>
+        public HybrasylDialogSequence NewEndSequence(string simpleDialog, string callback = "", string name = null)
+        {
+            DialogSequence sequence;
+            if (name == null)
+                sequence = new DialogSequence(Guid.NewGuid().ToString());
+            else
+                sequence = new DialogSequence(name);
+
+            var dialog = new SimpleDialog(simpleDialog);
+
+            if (!string.IsNullOrEmpty(callback))
+                dialog.CallbackExpression = callback;
+
+            sequence.AddDialog(dialog);
+            return new HybrasylDialogSequence(sequence);
+        }
+    
         public HybrasylDialog NewTextDialog(string displayText, string topCaption, string bottomCaption, int inputLength = 254, string callback="", string handler="")
         {
             var dialog = new TextDialog(displayText, topCaption, bottomCaption, inputLength);
@@ -136,6 +202,11 @@ namespace Hybrasyl.Scripting
                 else if (entry.Value is null)
                     // This is JUST an option, with no callback or jump dialog. The dialog handler will process the option itself.
                     dialog.AddDialogOption(entry.Key as string);
+                else if (entry.Value is HybrasylDialogSequence)
+                {
+                    var hds = entry.Value as HybrasylDialogSequence;
+                    dialog.AddDialogOption(entry.Key as string, hds.Sequence);
+                }
                 else
                     GameLog.Error($"Unknown type {entry.Value.GetType().Name} passed as argument to NewOptionsDialog call");
             }

--- a/hybrasyl/Scripting/HybrasylWorldObject.cs
+++ b/hybrasyl/Scripting/HybrasylWorldObject.cs
@@ -82,6 +82,39 @@ namespace Hybrasyl.Scripting
             }
         }
 
+        /// <summary>
+        /// Set a value in an object's ephemeral store. The store lasts for the
+        /// lifetime of the object (for mobs, until they're killed; for NPCs, most likely
+        /// until server restart, for players, while they're logged in).
+        /// </summary>
+        /// <param name="key">The key we will store</param>
+        /// <param name="value">The value (dynamic) we want to store</param>
+        public void StoreValue(string key, dynamic value)
+        {
+            if (Obj.EphemeralStore.TryGetValue(key, out dynamic oldValue))
+                Obj.EphemeralStore.TryUpdate(key, value, oldValue);
+            else
+                Obj.EphemeralStore.TryAdd(key, value);
+        }
+
+        /// <summary>
+        /// Remove the specified key from the object's ephemeral store.
+        /// </summary>
+        /// <param name="key"></param>
+        public void ClearValue(string key) => Obj.EphemeralStore.TryRemove(key, out _);
+        
+        /// <summary>
+        /// Get the value of a specified key from the object's ephemeral store.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public dynamic GetValue(string key)
+        {
+            if (Obj.EphemeralStore.TryGetValue(key, out dynamic value))
+                return value;
+            else return DynValue.Nil;
+        }
+
         public void RegisterSequence(HybrasylDialogSequence hybrasylSequence)
         {
             if (hybrasylSequence is null)

--- a/hybrasyl/Scripting/Script.cs
+++ b/hybrasyl/Scripting/Script.cs
@@ -153,6 +153,7 @@ namespace Hybrasyl.Scripting
                 Compiled.Globals["LegendIcon"] = UserData.CreateStatic<LegendIcon>();
                 Compiled.Globals["LegendColor"] = UserData.CreateStatic<LegendColor>();
                 Compiled.Globals["Class"] = UserData.CreateStatic<Class>();
+                Compiled.Globals["utility"] = typeof(HybrasylUtility);
                 Compiled.Globals.Set("world", UserData.Create(Processor.World));
                 Compiled.Globals.Set("logger", UserData.Create(new ScriptLogger(Name)));
                 Compiled.DoFile(FullPath);
@@ -194,6 +195,7 @@ namespace Hybrasyl.Scripting
 
             try
             {
+                Compiled.Globals["utility"] = typeof(HybrasylUtility);
                 Compiled.Globals.Set("invoker", GetUserDataValue(invoker));
                 // We pass Compiled.Globals here to make sure that the updated table (with new variables) makes it over
                 Compiled.DoString(expr, Compiled.Globals);
@@ -217,6 +219,7 @@ namespace Hybrasyl.Scripting
 
             try
             {
+                Compiled.Globals["utility"] = typeof(HybrasylUtility);
                 Compiled.Globals.Set("invoker", GetUserDataValue(invoker));
                 return Compiled.DoString(expr);
             }
@@ -240,6 +243,7 @@ namespace Hybrasyl.Scripting
             {
                 if (HasFunction(functionName))
                 {
+                    Compiled.Globals["utility"] = typeof(HybrasylUtility);
                     Compiled.Globals.Set("invoker", GetUserDataValue(invoker));
                     Compiled.Globals.Set("target", GetUserDataValue(target));
                     Compiled.Call(Compiled.Globals[functionName]);
@@ -268,6 +272,7 @@ namespace Hybrasyl.Scripting
             {
                 if (HasFunction(functionName))
                 {
+                    Compiled.Globals["utility"] = typeof(HybrasylUtility);
                     Compiled.Globals.Set("invoker", GetUserDataValue(invoker));
                     Compiled.Call(Compiled.Globals[functionName]);
                 }
@@ -295,7 +300,10 @@ namespace Hybrasyl.Scripting
             try
             {
                 if (HasFunction(functionName))
+                {
+                    Compiled.Globals["utility"] = typeof(HybrasylUtility);
                     Compiled.Call(Compiled.Globals[functionName]);
+                }
                 else
                     return false;
             }

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -2936,6 +2936,15 @@ namespace Hybrasyl
                     return;
                 }
 
+                // Are we transitioning between two dialog sequences? If so, show the first dialog from
+                // the new sequence and make sure we clear the previous state.
+                if (user.DialogState.PreviousPursuitId == pursuitID)
+                {
+                    user.DialogState.ActiveDialog.ShowTo(user, clickTarget);
+                    user.DialogState.PreviousPursuitId = null;
+                    return;
+                }
+
                 // Did the handling of a response result in our active dialog sequence changing? If so, exit.
 
                 if (user.DialogState.CurrentPursuitId != pursuitID)
@@ -3734,7 +3743,7 @@ namespace Hybrasyl
                     }
                     catch (Exception e)
                     {
-                        GameLog.Error("Exception encountered in packet handler!", e);
+                        GameLog.Error(e, "{Opcode}: Unhandled exception encountered in packet handler!", clientMessage.Packet.Opcode);
                     }
                 }
                 


### PR DESCRIPTION
* Add convenience functions for dialog generation (`NewTextAndJumpDialog`, `NewSimpleDialogSequence`, `NewEndDialog`)

  `NewSimpleDialogSequence` takes a list of strings and generates a dialog sequence consisting of the text passed to it. For instance:

  `NewSimpleDialogSequence("foobar", "a", "b", "c", "d")` would create a `DialogSequence` named "foobar" with four dialogs a->b->c->d.

  `NewTextAndJumpDialog` creates a sequence that displays one dialog and then jumps to something else. This is a convenience function that actually creates an anonymous sequence consisting of a `SimpleDialog` and a `JumpDialog`. You can use this to either jump to an arbitrary sequence, or, `MainMenu`, which will display the main menu.

  `NewEndDialog` creates a dialog that displays one reply and then "ends". This is useful for a dialog option which needs to terminate an NPC conversation / dialog tree after saying something.

* Add support to transition between two active dialog sequences

  To support the above, `DialogState` now correctly supports a dialog sequence changing without packet input, using the new function `TransitionDialog`.

* Add support for dialog options to trigger new sequences

  DialogOptions can now fire off Lua expressions, use `JumpDialogs`, or start entirely new `DialogSequences`.

* Implement TakeItem for scripts, so that NPCs can remove items from a player's inventory

  e.g. in scripts, `invoker.TakeItem('Moldy Baguette')` now works.

* Fix showcookies command

  Cookies are now properly displayed.

* Implement `{Clear|Set}Cookie` & `{Clear|Set}SessionCookie` commands for clearing permanent / session cookies

  Privileged users can use `/clearcookie <playername> <cookie>` and `/clearsessioncookie <player> <cookie>` to clear session and permanent cookies. This is very helpful for testing quests that rely on cookie functionality (e.g. certain amount of time has passed, etc). Similarly `/setcookie <player> <cookie> <cookie value>` works as expected.

* Implement ephemeral store support for all WorldObjects

  All `WorldObjects` now have, similar to `User` objects, an ephemeral key-value store for storing arbitrary data. This can be used by scripts to store a variety of arbitrary state data in any scriptable object: reactors, items, etc. This opens up a lot of interesting possibilities for future scripting and was also needed for Mileth scripting in particular. Scripts can now use `StoreValue`, `ClearValue` and `GetValue` as needed.

* Add utility class for Scripting API for a number of convenience functions

  This is exposed as the global object `utility` to Lua scripts. Currently, it exposes a number of simple functions to manipulate Terran dates and calculate the differences between two Unix timestamps, as well as get current Unix time. This can be used by scripts in combination with `SetCookie` et al to keep track of the last time a player did something, etc.

* Implement FindItem convenience function in WorldDataStore

  `FindItem('foobar')` will find the first instance of `Foobar` and deals with different genders.

* Bug: EndDialog scripting function should not only end dialog, but also close open dialog windows

## Description
Add significant functionality to scripting.

## Checklist
- [x] Tested and working locally
- [ ] Reviewed
- [ ] Tested and working on dev server
- [ ] Deployed to staging

## How to QA
Do the quest `Dark Things`.

## Impacted Areas in Hybrasyl
WorldDataStore - item fixes
Significant dialog processing changes 
New WorldObject `ConcurrentDictionary`-based ephemeral data store
