### PR TITLE
Loot testing fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,8 @@ bld/
 [Ll]og/
 
 # Visual Studio 2015 cache/options directory
-.vs/*
+*/.vs/*
+.vs
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/hybrasyl/Client.cs
+++ b/hybrasyl/Client.cs
@@ -512,7 +512,7 @@ namespace Hybrasyl
                             {
                                 UpdateLastReceived(packet.Opcode != 0x45 &&
                                                           packet.Opcode != 0x75);
-                                GameLog.Info($"Queuing: 0x{packet.Opcode:X2}");
+                                //GameLog.Info($"Queuing: 0x{packet.Opcode:X2}");
                                 // Check for throttling
                                 var throttleResult = Server.PacketThrottleCheck(this, packet);
                                 if (throttleResult == ThrottleResult.OK || throttleResult == ThrottleResult.ThrottleEnd || throttleResult == ThrottleResult.SquelchEnd)

--- a/hybrasyl/Map.cs
+++ b/hybrasyl/Map.cs
@@ -170,7 +170,11 @@ namespace Hybrasyl
         public Dictionary<Tuple<byte, byte>, Objects.Signpost> Signposts { get; set; }
         public Dictionary<Tuple<byte, byte>, Objects.Reactor> Reactors { get; set; }
 
-        public Dictionary<Monster, int> MapMonsters { get; set; }
+        public bool SpawnDebug { get; set; }
+
+        public bool SpawningDisabled { get; set; }
+
+        //public Dictionary<string, Xml.Spawn> Spawns { get; set; }
 
         /// <summary>
         /// Create a new Hybrasyl map from an XMLMap object.
@@ -181,6 +185,8 @@ namespace Hybrasyl
         {
             Init();
             World = theWorld;
+            SpawnDebug = false;
+          //  Spawns = new List<Xml.Spawn>();
 
             // TODO: refactor Map class to not do this, but be a partial which overlays
             // TODO: XSD.Map
@@ -588,6 +594,8 @@ namespace Hybrasyl
 
                     obj.Map = null;
                 }
+                else
+                    GameLog.Fatal("AIEEEEEEEEEEEEEEEE");
             }
         }
 

--- a/hybrasyl/Messaging/Debug.cs
+++ b/hybrasyl/Messaging/Debug.cs
@@ -20,9 +20,6 @@
  */
 
 using Hybrasyl.Objects;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Hybrasyl.Messaging
 {
@@ -46,6 +43,56 @@ namespace Hybrasyl.Messaging
                 target.ClearDialogState();
 
             return Success($"User {target.Name}: dialog state cleared.");
+        }
+    }
+
+    class MapDebugCommand : ChatCommand
+    {
+        public new static string Command = "mapdebug";
+        public new static string ArgumentText = "";
+        public new static string HelpText = "Turn on map debugging for the current map.";
+        public new static bool Privileged = true;
+
+        public new static ChatCommandResult Run(User user, params string[] args)
+        {
+            user.Map.SpawnDebug = !user.Map.SpawnDebug;
+            var str = user.Map.SpawnDebug ? "on" : "off";
+            return Success($"Map debugging for {user.Map.Name}: {str}");
+        }
+    }
+
+    class MapSpawnToggleCommand : ChatCommand
+    {
+        public new static string Command = "mapspawntoggle";
+        public new static string ArgumentText = "";
+        public new static string HelpText = "Toggle spawning for the current map.";
+        public new static bool Privileged = true;
+
+        public new static ChatCommandResult Run(User user, params string[] args)
+        {
+            user.Map.SpawningDisabled = !user.Map.SpawningDisabled;
+            var str = user.Map.SpawningDisabled ? "on" : "off";
+            return Success($"Spawning on {user.Map.Name}: {str}");
+        }
+    }
+
+    class SpawnToggleCommand : ChatCommand
+    {
+        public new static string Command = "spawntoggle";
+        public new static string ArgumentText = "<string spawngroup>";
+        public new static string HelpText = "Toggle whether the specified spawngroup is enabled or disabled.";
+        public new static bool Privileged = true;
+
+        public new static ChatCommandResult Run(User user, params string[] args)
+        {
+            if (Game.World.WorldData.TryGetValueByIndex<Xml.SpawnGroup>(args[0], out Xml.SpawnGroup group))
+            {
+                group.Disabled = !group.Disabled;
+                var str = group.Disabled ? "on" : "off";
+                return Success($"Spawngroup {args[0]}: spawning {str}");
+            }
+            else
+                return Fail($"Spawngroup {args[0]} not found");
         }
     }
 }

--- a/hybrasyl/WorldDataStore.cs
+++ b/hybrasyl/WorldDataStore.cs
@@ -231,17 +231,24 @@ namespace Hybrasyl
         /// <summary>
         /// Find all iterations (genders) of a given item name, if it exists.
         /// </summary>
-        /// <param name="name"></param>
+        /// <param name="name">A string name or SHA id of an item</param>
         /// <returns></returns>
         public List<Xml.Item> FindItem(string name)
-       {
+        {
+            // Check for an exact result first
             var ret = new List<Xml.Item>();
-            foreach (var gender in Enum.GetValues(typeof(Xml.Gender)))
+            Xml.Item target;
+            if (TryGetValue(name, out target) || TryGetValueByIndex(name, out target))
+                ret.Add(target);
+            else
             {
-                var rawhash = $"{name.Normalize()}:{gender.ToString().Normalize()}";
-                var hash = sha.ComputeHash(Encoding.ASCII.GetBytes(rawhash));
-                if (TryGetValue(string.Concat(hash.Select(b => b.ToString("x2"))).Substring(0, 8), out Xml.Item result))
-                    ret.Add(result);
+                foreach (var gender in Enum.GetValues(typeof(Xml.Gender)))
+                {
+                    var rawhash = $"{name.Normalize()}:{gender.ToString().Normalize()}";
+                    var hash = sha.ComputeHash(Encoding.ASCII.GetBytes(rawhash));
+                    if (TryGetValue(string.Concat(hash.Select(b => b.ToString("x2"))).Substring(0, 8), out Xml.Item result))
+                        ret.Add(result);
+                }
             }
             return ret;
         }


### PR DESCRIPTION
This PR fixes several bugs in looting / mob death based on testing.

* Fix several bugs in loot calculations
* Fix null reference exceptions in loot calculations / mob death
* Optimize monster spawn calculations, increase mob responsiveness
* Fix bug where low-powered variance would cause unhandled exceptions
* Ensure item variants specified in loot drop and serialize correctly

## Impacted Areas in Hybrasyl
List general components of Hybrasyl that this PR will affect:

Looting
Mob death (with looting)
