### PR TITLE
fix display issue where picked up items don't vanish on client side

### DIFF
--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -1579,12 +1579,13 @@ namespace Hybrasyl
 
                 toDrop = new ItemObject(toDrop);
                 toDrop.Count = count;
-                Insert(toDrop);
             }
             else
             {
                 user.RemoveItem(slot);
             }
+            // Item is being dropped and is "in the world" again
+            Insert(toDrop);
 
             // This is a normal item, not part of a loot anything
             toDrop.ItemDropTime = DateTime.Now;


### PR DESCRIPTION
## Description
This fixes a bug where only stackable items are inserted back into the world when dropped, which is necessary in order to assign them an ID. Later, when the item is picked back up, the server sends a remove packet with this ID; for non-stackable items this ID was being set to `0` rather than the correct value.

## How to QA
Repeat steps in #178, note that it is fixed.

## Impacted Areas in Hybrasyl
Item drop packet handler
