### PR TITLE
add Alive / SendHome; don't resurrect alive people

### DIFF
--- a/hybrasyl/Objects/Creature.cs
+++ b/hybrasyl/Objects/Creature.cs
@@ -847,7 +847,7 @@ namespace Hybrasyl.Objects
                 double armor = Stats.Ac * -1 + 100;
                 var elementTable = Game.World.WorldData.Get<Xml.ElementTable>("ElementTable");
                 var multiplier = elementTable.Source.First(x => x.Element == element).Target.FirstOrDefault(x => x.Element == Stats.BaseDefensiveElement).Multiplier;
-                 var reduction = damage * (armor / (armor + 50));
+                var reduction = damage * (armor / (armor + 50));
                 damage = (damage - reduction) * multiplier;
             }
 

--- a/hybrasyl/Scripting/HybrasylUser.cs
+++ b/hybrasyl/Scripting/HybrasylUser.cs
@@ -83,9 +83,28 @@ namespace Hybrasyl.Scripting
         /// </summary>
         public int Level { get => User.Stats.Level; }
 
+        /// <summary>
+        /// Amount of gold the user currently has.
+        /// </summary>
         public uint Gold { get => User.Gold; }
 
+        /// <summary>
+        /// Whether the user is alive or not.
+        /// </summary>
+        public bool Alive { get => User.Condition.Alive; }
+
+        /// <summary>
+        /// Give the specified amount of gold to the user.
+        /// </summary>
+        /// <param name="gold">Amount of gold to give.</param>
+        /// <returns></returns>
         public bool AddGold(uint gold) => User.AddGold(gold);
+
+        /// <summary>
+        /// Take the specified amount of gold from the user.
+        /// </summary>
+        /// <param name="gold">Amount of gold to take.</param>
+        /// <returns></returns>
         public bool RemoveGold(uint gold) => User.RemoveGold(gold);
 
         /// <summary>
@@ -131,7 +150,8 @@ namespace Hybrasyl.Scripting
         /// </summary>
         public void Resurrect()
         {
-            User.Resurrect();
+            if (!User.Condition.Alive)
+                User.Resurrect();
         }
 
         /// <summary>
@@ -159,6 +179,21 @@ namespace Hybrasyl.Scripting
         public void EndComa()
         {
             User.EndComa();
+        }
+
+        /// <summary>
+        /// Teleport a user to their "home" (ordinary spawnpoint), or a map of last resort.
+        /// </summary>
+        public void SendHome()
+        {
+            if (User.Nation.SpawnPoints.Count != 0)
+            {
+                var spawnpoint = User.Nation.RandomSpawnPoint;
+                if (spawnpoint != null) 
+                    User.Teleport(spawnpoint.MapName, spawnpoint.X, spawnpoint.Y);
+                return;
+            }
+            User.Teleport((ushort)500, (byte)50, (byte)(50));
         }
 
         /// <summary>

--- a/hybrasyl/Scripting/Script.cs
+++ b/hybrasyl/Scripting/Script.cs
@@ -214,7 +214,7 @@ namespace Hybrasyl.Scripting
             catch (Exception ex) when (ex is InterpreterException)
             {
                 GameLog.ScriptingError("{Function}: Error executing expression {expr} in {FileName} (invoker {Invoker}): {Message}",
-                    MethodBase.GetCurrentMethod().Name, expr, FileName, (invoker as WorldObject).Name,
+                    MethodBase.GetCurrentMethod().Name, expr, FileName, invoker.Name,
                     (ex as InterpreterException).DecoratedMessage);
                 //Disabled = true;
                 CompilationError = ex.ToString();
@@ -237,7 +237,7 @@ namespace Hybrasyl.Scripting
             catch (Exception ex) when (ex is InterpreterException)
             {
                 GameLog.ScriptingError("{Function}: Error executing expression: {expr} in {FileName} (invoker {Invoker}): {Message}",
-                    MethodBase.GetCurrentMethod().Name, expr, FileName, (invoker as WorldObject).Name,
+                    MethodBase.GetCurrentMethod().Name, expr, FileName, invoker.Name,
                     (ex as InterpreterException).DecoratedMessage);
                  //Disabled = true;
                 CompilationError = ex.ToString();
@@ -267,7 +267,7 @@ namespace Hybrasyl.Scripting
             catch (Exception ex) when (ex is InterpreterException)
             {
                 GameLog.ScriptingError("{Function}: Error executing function {ScriptFunction} in {FileName} (invoker {Invoker}): {Message}",
-                    MethodBase.GetCurrentMethod().Name, functionName, FileName, (invoker as WorldObject).Name,
+                    MethodBase.GetCurrentMethod().Name, functionName, FileName, invoker.Name,
                     (ex as InterpreterException).DecoratedMessage);
                 //Disabled = true;
                 CompilationError = ex.ToString();
@@ -299,7 +299,7 @@ namespace Hybrasyl.Scripting
             catch (Exception ex) when (ex is InterpreterException)
             {
                 GameLog.ScriptingError("{Function}: Error executing script function {ScriptFunction} in {FileName} (invoker {Invoker}): {Message}",
-                    MethodBase.GetCurrentMethod().Name, functionName, (invoker as WorldObject).Name, FileName,
+                    MethodBase.GetCurrentMethod().Name, functionName, invoker.Name, FileName,
                     (ex as InterpreterException).DecoratedMessage);
                 CompilationError = ex.ToString();
                 return false;


### PR DESCRIPTION
## Description
Check to see if someone is alive before resurrecting them. Also add `Alive` as a boolean field to `HybrasylUser` for scripts and `SendHome` to send a player back to their spawnpoint.
