### PR TITLE
Scripting fixes; fix bugs; add REPL scripting loop 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 
 # Build results
 [Dd]ebug/
-[Dd]ebugPublic/
+[Dd]ebugPublic/                     
 [Rr]elease/
 [Rr]eleases/
 x64/
@@ -79,7 +79,7 @@ artifacts/
 _Chutzpah*
 
 # Visual C++ cache files
-ipch/
+ipch/                     
 *.aps
 *.ncb
 *.opendb
@@ -280,3 +280,15 @@ __pycache__/
 **/XML/log.txt
 **/hybrasyl/log.txt
 **/*.txt
+
+XML/api
+XML/articles
+XML/site
+XML/docfx.json
+XML/toc.yml
+
+hybrasyl/api
+hybrasyl/articles
+hybrasyl/site
+hybrasyl/docfx.json
+hybrasyl/toc.yml

--- a/XML/XML.csproj
+++ b/XML/XML.csproj
@@ -15,7 +15,21 @@
   <!-- Continue to control versioning manually with AssemblyInfo.cs -->
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-  </PropertyGroup> 
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="api\**" />
+    <Compile Remove="articles\**" />
+    <Compile Remove="_site\**" />
+    <EmbeddedResource Remove="api\**" />
+    <EmbeddedResource Remove="articles\**" />
+    <EmbeddedResource Remove="_site\**" />
+    <None Remove="api\**" />
+    <None Remove="articles\**" />
+    <None Remove="_site\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="docfx.json" />
+  </ItemGroup> 
  
   <ItemGroup>
     <PackageReference Include="docfx" Version="2.53.1" />

--- a/hybrasyl/FormulaParser.cs
+++ b/hybrasyl/FormulaParser.cs
@@ -300,12 +300,12 @@ namespace Hybrasyl
                             break;
                         case "$CASTERWEAPONSDMGMIN":
                             {
-                                tokens[i] = (_caster.Equipment.Weapon?.MinSDamage ?? '0').ToString();
+                                tokens[i] = (_caster.Equipment.Weapon?.MinSDamage ?? '1').ToString();
                             }
                             break;
                         case "$CASTERWEAPONSDMGMAX":
                             {
-                                tokens[i] = (_caster.Equipment.Weapon?.MaxSDamage ?? '0').ToString();
+                                tokens[i] = (_caster.Equipment.Weapon?.MaxSDamage ?? '1').ToString();
                             }
                             break;
                         case "$CASTERWEAPONLDMG":
@@ -325,12 +325,12 @@ namespace Hybrasyl
                             break;
                         case "$CASTERWEAPONLDMGMIN":
                             {
-                                tokens[i] = (_caster.Equipment.Weapon?.MinLDamage ?? '0').ToString();
+                                tokens[i] = (_caster.Equipment.Weapon?.MinLDamage ?? '1').ToString();
                             }
                             break;
                         case "$CASTERWEAPONLDMGMAX":
                             {
-                                tokens[i] = (_caster.Equipment.Weapon?.MaxLDamage ?? '0').ToString();
+                                tokens[i] = (_caster.Equipment.Weapon?.MaxLDamage ?? '1').ToString();
                             }
                             break;
                         case "$CASTABLELEVEL":

--- a/hybrasyl/FormulaParser.cs
+++ b/hybrasyl/FormulaParser.cs
@@ -271,51 +271,66 @@ namespace Hybrasyl
                         case "$CASTERWEAPONDMG":
                             {
                                 var rand = new Random();
-                                var mindmg = (int)_caster.Equipment.Weapon.MinSDamage;
-                                var maxdmg = (int)_caster.Equipment.Weapon.MaxSDamage;
-                                if (mindmg == 0) mindmg = 1;
-                                if (maxdmg == 0) maxdmg = 1;
-                                tokens[i] = rand.Next(mindmg, maxdmg).ToString();
+                                if (_caster.Equipment.Weapon == null)
+                                    tokens[i] = "0";
+                                else
+                                {
+                                    var mindmg = (int)_caster.Equipment.Weapon.MinSDamage;
+                                    var maxdmg = (int)_caster.Equipment.Weapon.MaxSDamage;
+                                    if (mindmg == 0) mindmg = 1;
+                                    if (maxdmg == 0) maxdmg = 1;
+                                    tokens[i] = rand.Next(mindmg, maxdmg).ToString();
+                                }
                             }
                             break;
                         case "$CASTERWEAPONSDMG":
                             {
                                 var rand = new Random();
-                                var mindmg = (int)_caster.Equipment.Weapon.MinSDamage;
-                                var maxdmg = (int)_caster.Equipment.Weapon.MaxSDamage;
-                                if (mindmg == 0) mindmg = 1;
-                                if (maxdmg == 0) maxdmg = 1;
-                                tokens[i] = rand.Next(mindmg, maxdmg).ToString();
+                                if (_caster.Equipment.Weapon == null)
+                                    tokens[i] = "0";
+                                else
+                                {
+                                    var mindmg = (int)_caster.Equipment.Weapon.MinSDamage;
+                                    var maxdmg = (int)_caster.Equipment.Weapon.MaxSDamage;
+                                    if (mindmg == 0) mindmg = 1;
+                                    if (maxdmg == 0) maxdmg = 1;
+                                    tokens[i] = rand.Next(mindmg, maxdmg).ToString();
+                                }
                             }
                             break;
                         case "$CASTERWEAPONSDMGMIN":
                             {
-                                tokens[i] = _caster.Equipment.Weapon.MinSDamage.ToString();
+                                tokens[i] = (_caster.Equipment.Weapon?.MinSDamage ?? '0').ToString();
                             }
                             break;
                         case "$CASTERWEAPONSDMGMAX":
                             {
-                                tokens[i] = _caster.Equipment.Weapon.MaxSDamage.ToString();
+                                tokens[i] = (_caster.Equipment.Weapon?.MaxSDamage ?? '0').ToString();
                             }
                             break;
                         case "$CASTERWEAPONLDMG":
                             {
                                 var rand = new Random();
-                                var mindmg = (int)_caster.Equipment.Weapon.MinLDamage;
-                                var maxdmg = (int)_caster.Equipment.Weapon.MaxLDamage;
-                                if (mindmg == 0) mindmg = 1;
-                                if (maxdmg == 0) maxdmg = 1;
-                                tokens[i] = rand.Next(mindmg, maxdmg).ToString();
+                                if (_caster.Equipment.Weapon == null)
+                                    tokens[i] = "0";
+                                else
+                                {
+                                    var mindmg = (int)_caster.Equipment.Weapon.MinLDamage;
+                                    var maxdmg = (int)_caster.Equipment.Weapon.MaxLDamage;
+                                    if (mindmg == 0) mindmg = 1;
+                                    if (maxdmg == 0) maxdmg = 1;
+                                    tokens[i] = rand.Next(mindmg, maxdmg).ToString();
+                                }
                             }
                             break;
                         case "$CASTERWEAPONLDMGMIN":
                             {
-                                tokens[i] = _caster.Equipment.Weapon.MinLDamage.ToString();
+                                tokens[i] = (_caster.Equipment.Weapon?.MinLDamage ?? '0').ToString();
                             }
                             break;
                         case "$CASTERWEAPONLDMGMAX":
                             {
-                                tokens[i] = _caster.Equipment.Weapon.MaxLDamage.ToString();
+                                tokens[i] = (_caster.Equipment.Weapon?.MaxLDamage ?? '0').ToString();
                             }
                             break;
                         case "$CASTABLELEVEL":

--- a/hybrasyl/Hybrasyl.csproj
+++ b/hybrasyl/Hybrasyl.csproj
@@ -15,6 +15,19 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="api\**" />
+    <Compile Remove="articles\**" />
+    <Compile Remove="_site\**" />
+    <EmbeddedResource Remove="api\**" />
+    <EmbeddedResource Remove="articles\**" />
+    <EmbeddedResource Remove="_site\**" />
+    <None Remove="api\**" />
+    <None Remove="articles\**" />
+    <None Remove="_site\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="docfx.json" />
     <None Remove="Resources\sotp.dat" />
   </ItemGroup>
 

--- a/hybrasyl/Inventory.cs
+++ b/hybrasyl/Inventory.cs
@@ -821,18 +821,9 @@ namespace Hybrasyl
                 if (!_inventoryIndex.ContainsKey(item.Id))
                     continue;
 
-                var quant = 0;
-
-                foreach (var itm in _inventoryIndex.Where(x => x.Key == item.Id).ToList())
-                {
-                    foreach (var i in itm.Value)
-                    {
-                        quant += i.Count;
-                    }
-                }
-                var hasQuantity = quant >= quantity;
-                if (quant >= quantity)
-                    return true;
+                var total = _inventoryIndex.Where(x => x.Key == item.Id).First().Value.Sum(y => y.Count);
+                GameLog.Info($"Contains check: {name}, quantity {quantity}: {total} found");
+                if (total >= quantity) return true;
             }
             return false;
         }

--- a/hybrasyl/Legend.cs
+++ b/hybrasyl/Legend.cs
@@ -41,15 +41,22 @@ namespace Hybrasyl
 
         private Dictionary<string, LegendMark> _legendIndex = new Dictionary<string, LegendMark>();
 
-        public bool TryGetMark(string prefix, out LegendMark mark)
+        public bool TryGetMark(string searchKey, out LegendMark mark, bool byPrefix = true)
         {
-            return _legendIndex.TryGetValue(prefix, out mark);
+            if (byPrefix)
+                return _legendIndex.TryGetValue(searchKey, out mark);
+            else
+            {
+                // Return first mark that matches
+                mark = _legend.Values.Where(x => x.Text.ToLower().Contains(searchKey.ToLower())).First();
+                return mark != null;
+            }
         }
 
         private bool _addLegendMark(LegendMark mark)
         {
             if (_legend.Keys.Count == MaximumLegendSize) return false;
-            if (!string.IsNullOrEmpty(mark.Prefix) && _legendIndex.ContainsKey(mark.Prefix))
+            if (_legendIndex.ContainsKey(mark.Prefix))
                 throw new ArgumentException("A legend mark's prefix must be unique for a given character");
             _legend.Add(mark.Timestamp, mark);
             if (mark.Prefix != null)
@@ -92,8 +99,9 @@ namespace Hybrasyl
             if (_legendIndex.Count == _legend.Count) return;
             _legendIndex = new Dictionary<string, LegendMark>();
             foreach (var kvp in _legend)
-            {
-                _legendIndex[kvp.Value.Prefix] = kvp.Value;
+            {             
+                if (kvp.Value.Prefix != null)
+                    _legendIndex[kvp.Value.Prefix] = kvp.Value;
             }
         }
 

--- a/hybrasyl/Objects/Creature.cs
+++ b/hybrasyl/Objects/Creature.cs
@@ -138,10 +138,11 @@ namespace Hybrasyl.Objects
                     if (target == null)
                         GameLog.Error($"GetTargets: {castable.Name} - intent was for exact clicked target but no target was passed?");
                     else
-                        // Heal spels can be cast on players, other spells can be cast on attackable creatures
-                        if ((!castable.Effects.Damage.IsEmpty && target.Condition.IsAttackable) ||
-                        (castable.Effects.Damage.IsEmpty && target is User))
-                        possibleTargets.Add(target);
+                        // If we're doing damage, ensure the target is attackable
+                        if (!castable.Effects.Damage.IsEmpty && target.Condition.IsAttackable)
+                            possibleTargets.Add(target);
+                        else if (castable.Effects.Damage.IsEmpty)
+                            possibleTargets.Add(target);
                 }
                 else if (intent.UseType == Xml.SpellUseType.NoTarget && intent.Radius == 0 && intent.Direction == Xml.IntentDirection.None)
                 {
@@ -549,7 +550,7 @@ namespace Hybrasyl.Objects
                     if (this is User) GameLog.UserActivityInfo($"UseCastable: {Name} casting {castObject.Name} - target: {tar.Name} damage: {damageOutput}, element {attackElement}");
 
                     tar.Damage(damageOutput.Amount, attackElement, damageOutput.Type, damageOutput.Flags, this, false);
-                    if (this is User)
+                    if (this is User && Equipment.Weapon != null)
                         Equipment.Weapon.Durability -= 1 / (Equipment.Weapon.MaximumDurability * (100 - Stats.Ac));
 
                     if (tar.Stats.Hp <= 0) { deadMobs.Add(tar); }
@@ -563,7 +564,8 @@ namespace Hybrasyl.Objects
                     if (this is User)
                     {
                         GameLog.UserActivityInfo($"UseCastable: {Name} casting {castObject.Name} - target: {tar.Name} healing: {healOutput}");
-                        Equipment.Weapon.Durability -= 1 / (Equipment.Weapon.MaximumDurability * (100 - Stats.Ac));
+                        if (Equipment.Weapon != null)
+                           Equipment.Weapon.Durability -= 1 / (Equipment.Weapon.MaximumDurability * (100 - Stats.Ac));
                     }
                 }
 

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -1824,12 +1824,12 @@ namespace Hybrasyl.Objects
 
         public bool AddSkill(Xml.Castable castable)
         {
-            if (SkillBook.IsFull)
+            if (SkillBook.IsFull(castable.Book))
             {
                 SendSystemMessage("You cannot learn any more skills.");
                 return false;
             }
-            return AddSkill(castable, SkillBook.FindEmptySlot());
+            return AddSkill(castable, SkillBook.FindEmptySlot(castable.Book));
         }
 
         public bool AddSkill(Xml.Castable item, byte slot)
@@ -1858,12 +1858,12 @@ namespace Hybrasyl.Objects
 
         public bool AddSpell(Xml.Castable castable)
         {
-            if (SpellBook.IsFull)
+            if (SpellBook.IsFull(castable.Book))
             {
                 SendSystemMessage("You cannot learn any more spells.");
                 return false;
             }
-            return AddSpell(castable, SpellBook.FindEmptySlot());
+            return AddSpell(castable, SpellBook.FindEmptySlot(castable.Book));
         }
 
         public bool AddSpell(Xml.Castable item, byte slot)

--- a/hybrasyl/Objects/VisibleObject.cs
+++ b/hybrasyl/Objects/VisibleObject.cs
@@ -163,11 +163,6 @@ namespace Hybrasyl.Objects
         {
         }
 
-        public virtual void Remove()
-        {
-            Map.Remove(this);
-        }
-
         public virtual void Teleport(ushort mapid, byte x, byte y)
         {
             if (!World.WorldData.ContainsKey<Map>(mapid)) return;

--- a/hybrasyl/Scripting/HybrasylUser.cs
+++ b/hybrasyl/Scripting/HybrasylUser.cs
@@ -623,10 +623,16 @@ namespace Hybrasyl.Scripting
         /// <returns>Boolean indicating whether or not it the item was successfully removed from the player's inventory.</returns>
         public bool TakeItem(string name, int count = 1)
         {
-            if (User.Inventory.ContainsName(name) && User.RemoveItem(name, (ushort) count))
-                return true;
-            GameLog.ScriptingDebug("{Function}: User {User} doesn't have {item}",
-                MethodInfo.GetCurrentMethod().Name, User.Name, name);
+            if (User.Inventory.ContainsName(name))
+            {
+                if (User.RemoveItem(name, (ushort)count))
+                    return true;
+                else
+                    GameLog.ScriptingWarning("{Function}: User {User} removeitem failed for {item}", MethodInfo.GetCurrentMethod().Name, User.Name, name);
+            }
+            else
+                GameLog.ScriptingWarning("{Function}: User {User} doesn't have {item}", MethodInfo.GetCurrentMethod().Name, User.Name, name);
+
             return false;
         }
 

--- a/hybrasyl/Scripting/ScriptProcessor.cs
+++ b/hybrasyl/Scripting/ScriptProcessor.cs
@@ -72,9 +72,14 @@ namespace Hybrasyl.Scripting
             return false;
         }
 
-        public void RegisterScript(Script script)
+        public void RegisterScript(Script script, bool run=true)
         {
-            script.Run();
+            if (script.Processor == null)
+                script.Processor = this;
+
+            if (run)
+                script.Run();
+
             var name = SanitizeName(script.Name);
             if (!_scripts.ContainsKey(name))
             {

--- a/hybrasyl/Utility.cs
+++ b/hybrasyl/Utility.cs
@@ -29,6 +29,22 @@ using System.Text.RegularExpressions;
 namespace Hybrasyl
 {
 
+    public static class Extensions
+    {
+        public static IEnumerable<string> Split(this string str, int n)
+        {
+            if (String.IsNullOrEmpty(str) || n < 1)
+            {
+                throw new ArgumentException();
+            }
+
+            for (int i = 0; i < str.Length; i += n)
+            {
+                yield return str.Substring(i, Math.Min(n, str.Length - i));
+            }
+        }
+    }
+
     public static class EnumerableExtension
     {
         public static T PickRandom<T>(this IEnumerable<T> source)

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -1964,7 +1964,7 @@ namespace Hybrasyl
 
                 listPacket.WriteByte((byte)user.Class);
                 if (me.GuildUuid != string.Empty && user.GuildUuid == me.GuildUuid) listPacket.WriteByte(84);
-                if (levelDifference <= 5) listPacket.WriteByte(151);
+                else if (levelDifference <= 5) listPacket.WriteByte(151);
                 else listPacket.WriteByte(255);
 
                 listPacket.WriteByte((byte)user.GroupStatus);

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -25,6 +25,7 @@ using Hybrasyl.Messaging;
 using Hybrasyl.Objects;
 using Hybrasyl.Scripting;
 using Hybrasyl.Utility;
+using MoonSharp.Interpreter;
 using Newtonsoft.Json;
 using Serilog;
 using StackExchange.Redis;
@@ -988,7 +989,7 @@ namespace Hybrasyl
                         {
                             var scriptname = Path.GetFileName(file);
                             GameLog.InfoFormat("Loading script {0}\\{1}", dir, scriptname);
-                            var script = new Script(file, ScriptProcessor);
+                            var script = new Scripting.Script(file, ScriptProcessor);
                             ScriptProcessor.RegisterScript(script);
                             if (dir == "common")
                                 script.Run();
@@ -1990,10 +1991,58 @@ namespace Hybrasyl
             {
                 user.SendGroupWhisper(message);
             }
-            else
+            else if (target == "$")
             {
-                user.SendWhisper(target, message);
+                if (!user.IsPrivileged)
+                {
+                    user.SendSystemMessage("Forbidden.");
+                    return;
+                }
+
+                Scripting.Script script;
+
+                if (!ScriptProcessor.TryGetScript($"{user.Name}-repl.lua", out script) || message.ToLower().Contains("--clear--"))
+                {
+                    // Make new magic script if needed
+                    if (ScriptProcessor.TryGetScript("repl.lua", out Scripting.Script newScript))
+                    {
+                        newScript.Name = $"{user.Name}-repl.lua";
+                        ScriptProcessor.RegisterScript(newScript);
+                        newScript.Execute($"init('{user.Name}')", user);
+                        user.DisplayIncomingWhisper("$", "Eval environment ready");
+                        return;
+                    }
+                    else
+                    {
+                        user.SendSystemMessage("repl.lua needs to exist as a script first");
+                        return;
+                    }
+                }
+                user.DisplayOutgoingWhisper("$", message);
+                // Tack on return here so we actually get the DynValue out
+                var ret = script.Execute($"return {message}", user);
+                if (!ret)
+                {
+                    var strs = script.LastRuntimeError.Split(50);
+                    foreach (var str in strs)
+                        user.DisplayIncomingWhisper("$", $"Err: {str}");
+                }
+                else
+                {
+                    if (script.LastReturnValue == DynValue.Nil || script.LastReturnValue == DynValue.Void)
+                        user.DisplayIncomingWhisper("$", "Ret: nil (OK)");
+                    // this is deeply annoying and stupid
+                    else if (script.LastReturnValue.Type == DataType.Boolean)
+                        user.DisplayIncomingWhisper("$", $"Ret: {script.LastReturnValue.Boolean.ToString()}");
+                    else
+                        user.DisplayIncomingWhisper("$", $"Ret: {script.LastReturnValue.CastToString()}");
+
+                }
+                return;
+
             }
+            else
+                user.SendWhisper(target, message);
         }
 
         [Prohibited(Xml.CreatureCondition.Coma, Xml.CreatureCondition.Sleep, Xml.CreatureCondition.Freeze)]
@@ -3935,7 +3984,7 @@ namespace Hybrasyl
 
             if (obj is ItemObject)
             {
-                Script itemscript;
+                Scripting.Script itemscript;
                 if (Game.World.ScriptProcessor.TryGetScript(obj.Name, out itemscript))
                 {
                     var clone = itemscript.Clone();


### PR DESCRIPTION
## Description
HYB-64: bugfixing
HYB-82: correct requirement for legend marks to have prefixes
HYB-18: /legend now allows dates / quantities to be properly set for testing, and doesn't make it so you can't login 😄 
HYB-36 / #145 - correctly handle primary/secondary/utility skills in panes
HYB-79: perform null checks for formula parser tokens that may be null

**Other**

Add slight-REPL loop for scripting usage, using whisper target $
Fix error in intent calculations: monsters should always be healable / statusable
Fix crash error in `e` (who list)
Fix null check error in weapon durability

