### PR TITLE
Dialog bug squashing, teleport updates, fixes

### DIFF
--- a/hybrasyl/FormulaParser.cs
+++ b/hybrasyl/FormulaParser.cs
@@ -447,7 +447,6 @@ namespace Hybrasyl
                         case "$RAND_1000":
                             tokens[i] = _rnd.Next(0, 1000).ToString();
                             break;
-
                         default:
                             tokens[i] = "0";
                             return false;

--- a/hybrasyl/Map.cs
+++ b/hybrasyl/Map.cs
@@ -414,7 +414,6 @@ namespace Hybrasyl
             return false;
         }
 
-
         public void Insert(VisibleObject obj, byte x, byte y, bool updateClient = true)
         {
             lock (_lock)
@@ -700,6 +699,42 @@ namespace Hybrasyl
         public bool IsValidPoint(short x, short y)
         {
             return x >= 0 && x < X && y >= 0 && y < Y;
+        }
+
+        /// <summary>
+        /// Find the nearest empty tile (e.g. non-wall) next to
+        /// </summary>
+        /// <param name="xStart"></param>
+        /// <param name="yStart"></param>
+        /// <returns></returns>
+        public (byte x, byte y) FindEmptyTile(byte xStart, byte yStart)
+        {
+            byte retx = 0;
+            byte rety = 0;
+            int radius = 1;
+            // TODO: update to check for map being full / other edge cases
+            do
+            {   
+                for (int x = -1 * radius; x <= radius; x++)
+                {
+                    for (int y = -1 * radius; y <= radius; y++)
+                    {
+                        if (IsWall[xStart + x, yStart + y] || GetTileContents(xStart + x, yStart + y).Where(x => x is Creature).Count() > 0)
+                            continue;
+                        else
+                        {
+                            retx = (byte) (xStart + x);
+                            rety = (byte) (yStart + y);
+                            break;
+                        }
+                    }
+                }
+                radius++;
+                // Don't go on forever here
+                if (radius > 3) break;
+            } while (true);
+
+            return (retx, rety);
         }
  
     }

--- a/hybrasyl/Scripting/HybrasylUser.cs
+++ b/hybrasyl/Scripting/HybrasylUser.cs
@@ -568,6 +568,25 @@ namespace Hybrasyl.Scripting
         }
 
         /// <summary>
+        /// Check to see if a user has the specified cookie; if not, set it, give experience, and optionally, send them a system message.
+        /// </summary>
+        /// <param name="cookie">Name of the cookie to be set.</param>
+        /// <param name="xp">Amount of XP to award.</param>
+        /// <param name="completionMessage">A system message that will be sent to the user.</param>
+        /// <returns>Boolean indicating whether or not the user was awarded XP.</returns>
+        public bool CompletionAward(string cookie, uint xp = 0, string completionMessage = null)
+        {
+            if (User.HasCookie(cookie))
+                return false;
+            User.SetCookie(cookie, new DateTimeOffset(DateTime.Now).ToUnixTimeSeconds().ToString());
+            if (xp > 0)
+                User.GiveExperience(xp);
+            if (!string.IsNullOrEmpty(completionMessage))
+                User.SendSystemMessage(completionMessage);
+            return true;
+        }
+
+        /// <summary>
         /// Give a new instance of the named item to a player, optionally with a specified quantity.
         /// </summary>
         /// <param name="name">The name of the item to be created.</param>

--- a/hybrasyl/Scripting/HybrasylWorld.cs
+++ b/hybrasyl/Scripting/HybrasylWorld.cs
@@ -312,10 +312,13 @@ namespace Hybrasyl.Scripting
         /// Create a jump dialog, which is an "invisible" dialog that is used to start a new sequence from a subdialog. Can be used to jump between different NPC dialogue branches.
         /// </summary>
         /// <param name="targetSequence">The name of the sequence that will start when this JumpDialog is "shown" to the player.</param>
+        /// <param name="callbackExpression">A lua expression that will run when this dialog is shown to the player.</param>
         /// <returns>The constructed dialog</returns>
-        public HybrasylDialog NewJumpDialog(string targetSequence)
+        public HybrasylDialog NewJumpDialog(string targetSequence, string callbackExpression = null)
         {
             var dialog = new JumpDialog(targetSequence);
+            if (!string.IsNullOrEmpty(callbackExpression))
+                dialog.SetCallbackHandler(callbackExpression);
             return new HybrasylDialog(dialog);
         }
 

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -3085,11 +3085,12 @@ namespace Hybrasyl
             var pursuitID = packet.ReadUInt16();
             var pursuitIndex = packet.ReadUInt16();
 
-            GameLog.DebugFormat("objectType {0}, objectID {1}, pursuitID {2}, pursuitIndex {3}",
-                objectType, objectID, pursuitID, pursuitIndex);
+            GameLog.DebugFormat($"0x3A   user: {user.Name} objectType {objectType} objectID {objectID} pursuitID {pursuitID} pursuitIndex {pursuitIndex}");
 
-            GameLog.DebugFormat("active dialog via state object: pursuitID {0}, pursuitIndex {1}",
-                user.DialogState.CurrentPursuitId, user.DialogState.CurrentPursuitIndex);
+            GameLog.DebugFormat("0x3A   DialogState: previous {prev}, current {cur}, pursuitIndex {pidx}",
+                user.DialogState.PreviousPursuitId?.ToString() ?? "null",
+                user.DialogState.CurrentPursuitId, 
+                user.DialogState.CurrentPursuitIndex);
 
             AsyncDialogRequest request = null;
             VisibleObject source = null;
@@ -3268,17 +3269,7 @@ namespace Hybrasyl
                     return;
                 }
 
-                // Are we transitioning between two dialog sequences? If so, show the first dialog from
-                // the new sequence and make sure we clear the previous state.
-                if (user.DialogState.PreviousPursuitId == pursuitID)
-                {
-                    user.DialogState.ActiveDialog.ShowTo(user, clickTarget);
-                    user.DialogState.PreviousPursuitId = null;
-                    return;
-                }
-
                 // Did the handling of a response result in our active dialog sequence changing? If so, exit.
-
                 if (user.DialogState.CurrentPursuitId != pursuitID)
                 {
                     GameLog.ErrorFormat("Dialog has changed, exiting");


### PR DESCRIPTION
This PR fixes a number of bugs identified by @SmashleyMcNerdface while doing Mileth scripting. It also provides a few enhancements.

* Allow JumpDialogs to specify Lua callbacks via scripting, and ense they are run.
* Update /teleport to take NPC name or map name.
* Add FindEmptyTile to Map for scripting / command usage.
* Add CompletionAward to be used in scripting for simple check-if-user-has-done-this-if-not-give-xp steps (Graymayre, et al)

## How to QA
Observe that `NewTextAndJumpDialogs` are not duplicated (before, Menu->Select A->B->C->Menu was being rendered as Menu->Select A->B->B->C->Menu).

## Impacted Areas in Hybrasyl
Scripting / dialogs
