### PR TITLE
refactor async packet delivery

### DIFF
--- a/hybrasyl/Enums.cs
+++ b/hybrasyl/Enums.cs
@@ -80,16 +80,21 @@ namespace Hybrasyl
         /// </summary>
         public enum LegendColor
         {
+            Aqua = 1,
             White = 32,
+            Pink = 36,
+            Peony = 36,
             LightOrange = 50,
+            Mahogany = 53,
+            Brass = 63,
             LightYellow = 64,
             Yellow = 68,
             LightGreen = 75,
+            Teal = 87,
             Blue = 88,
             LightPink = 96,
             DarkPurple = 100,
-            Pink = 105,
-            Darkgreen = 125,
+            Lavender = 105,
             Green = 128,
             Orange = 152,
             Brown = 160,

--- a/hybrasyl/Map.cs
+++ b/hybrasyl/Map.cs
@@ -583,8 +583,10 @@ namespace Hybrasyl
                         // If the target of a Remove is a player, we insert a 250ms delay to allow the animation
                         // frame to complete, or a slight delay to allow a kill animation to finish animating.
                         // Yes, this is a thing we do.
-                        if (target is User)
-                            ((User)target).AoiDeparture(obj, obj is User ? 250 : 100);
+                        if (target is User && obj is User)
+                            ((User)target).AoiDeparture(obj, 250);
+                        else if (target is User && obj is Creature)
+                            ((User)target).AoiDeparture(obj, 100);
                         else
                             target.AoiDeparture(obj);
 
@@ -795,7 +797,6 @@ namespace Hybrasyl
                     Map map;
                     if (SourceMap.World.WorldData.TryGetValueByIndex(DestinationMapName, out map))
                     {
-                        Thread.Sleep(250);
                         target.Teleport(map.Id, DestinationX, DestinationY);
                         return true;
                     }

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -340,6 +340,7 @@ namespace Hybrasyl.Objects
             GameLog.Debug("Removing ItemObject with ID {Id}", obj.Id);
             var removePacket = new ServerPacket(0x0E);
             removePacket.WriteUInt32(obj.Id);
+            removePacket.TransmitDelay = 250;
             Enqueue(removePacket);
         }
 

--- a/hybrasyl/Packet.cs
+++ b/hybrasyl/Packet.cs
@@ -34,7 +34,6 @@ namespace Hybrasyl
     [Serializable]
     public abstract class Packet
     {
-
         protected static byte[][] SaltTable = new byte[][]
     {
       #region Seed 00


### PR DESCRIPTION
## Description
When async outbound delivery of packets was introduced, it created a race condition where packets can be received out of order by the client. This had a number of knockoff effects where packets need to be received in order (such as picking an item up off the ground, etc).

This PR introduces the concept of a server thread that runs asynchronously to deliver packets. The `Enqueue` is changed to only enqueue packets into the concurrent queue; the server thread is responsible for delivery. Currently, this thread runs asynchronously every 50ms.

This is a suggestion for how to fix it - I am more than happy to get feedback and suggestions.

## How to QA
In particular, test map renders correctly (GM Test Area) and the issues noticed in HYB-94 are resolved (picking an item up over your weight results in item "vanishing" from client).

## Impacted Areas in Hybrasyl
All packet delivery.
