### PR TITLE
Improvements to error reporting 

### DIFF
--- a/XML/XSD/Common.xsd
+++ b/XML/XSD/Common.xsd
@@ -268,6 +268,7 @@
               <xs:enumeration value="Unique" />
               <xs:enumeration value="Master" />
               <xs:enumeration value="Unique-Equipped" />
+              <xs:enumeration value="Identifiable"/>
             </xs:restriction>
           </xs:simpleType>
         </xs:list>

--- a/XML/XSD/Item.xsd
+++ b/XML/XSD/Item.xsd
@@ -235,6 +235,7 @@
   <xs:complexType name="Item">
     <xs:sequence>
       <xs:element name="Name" minOccurs="1" maxOccurs="1" type="hyb:String8" />
+      <xs:element name="UnidentifiedName" minOccurs="0" maxOccurs="1" type="hyb:String8"/>
       <xs:element name="Comment" minOccurs="0" maxOccurs="1" type="hyb:String16" />
       <xs:element name="Properties" minOccurs="1" maxOccurs="1" type="hyb:ItemProperties" />
     </xs:sequence>

--- a/XML/XSD/Objects/Item.cs
+++ b/XML/XSD/Objects/Item.cs
@@ -29,6 +29,7 @@ public partial class Item
 {
     #region Private fields
     private string _name;
+    private string _unidentifiedName;
     private string _comment;
     private ItemProperties _properties;
     private static XmlSerializer _serializer;
@@ -49,6 +50,19 @@ public partial class Item
         set
         {
             _name = value;
+        }
+    }
+    
+    [StringLengthAttribute(255, MinimumLength=1)]
+    public string UnidentifiedName
+    {
+        get
+        {
+            return _unidentifiedName;
+        }
+        set
+        {
+            _unidentifiedName = value;
         }
     }
     

--- a/XML/XSD/Objects/ItemFlags.cs
+++ b/XML/XSD/Objects/ItemFlags.cs
@@ -39,6 +39,7 @@ public enum ItemFlags
     [XmlEnumAttribute("Unique-Equipped")]
     [EnumMember(Value="Unique-Equipped")]
     UniqueEquipped = 2048,
+    Identifiable = 4096,
 }
 }
 #pragma warning restore

--- a/hybrasyl/Map.cs
+++ b/hybrasyl/Map.cs
@@ -268,6 +268,7 @@ namespace Hybrasyl
                 InsertNpc(merchant);
                 // Keep the actual spawned object around in the index for later use
                 World.WorldData.Set(merchant.Name, merchant);
+
             }
 
             foreach (var reactorElement in newMap.Reactors)

--- a/hybrasyl/Objects/ItemObject.cs
+++ b/hybrasyl/Objects/ItemObject.cs
@@ -138,6 +138,11 @@ namespace Hybrasyl.Objects
 
         public uint MaximumDurability => Template.Properties.Physical.Durability;
 
+        // For future use / expansion re: unidentified items.
+        // Should pull from template and only allow false to be set when
+        // Identifiable flag is set.
+        public bool Identified => true;
+
         public byte Level => Template.Level;
         public byte Ability => Template.Ability;
         public Xml.Class Class => Template.Class;
@@ -226,7 +231,7 @@ namespace Hybrasyl.Objects
                     return;
                 }
 
-                if (!invokeScript.ExecuteFunction("OnUse", trigger, null, this))
+                if (!invokeScript.ExecuteFunction("OnUse", this, trigger, this))
                 {
                     trigger.SendSystemMessage("It doesn't work.");
                     return;

--- a/hybrasyl/Objects/Monster.cs
+++ b/hybrasyl/Objects/Monster.cs
@@ -109,6 +109,7 @@ namespace Hybrasyl.Objects
             // FIXME: in the glorious future, run asynchronously with locking
             if (World.ScriptProcessor.TryGetScript(Name, out Script damageScript))
             {
+                damageScript.AssociateScriptWithObject(this);
                 damageScript.SetGlobalValue("damage", damage);
                 damageScript.ExecuteFunction("OnDamage", this, attacker);
             }
@@ -119,6 +120,7 @@ namespace Hybrasyl.Objects
             // FIXME: in the glorious future, run asynchronously with locking
             if (World.ScriptProcessor.TryGetScript(Name, out Script healScript))
             {
+                healScript.AssociateScriptWithObject(this);
                 healScript.SetGlobalValue("heal", heal);
                 healScript.ExecuteFunction("OnHeal", this, healer);
             }

--- a/hybrasyl/Scripting/HybrasylDialog.cs
+++ b/hybrasyl/Scripting/HybrasylDialog.cs
@@ -61,6 +61,11 @@ namespace Hybrasyl.Scripting
         /// <param name="sequence"></param>
         public void AssociateDialogWithSequence(DialogSequence sequence)
         {
+            if (sequence is null)
+            {
+                GameLog.ScriptingError("AssociateDialogWithSequence: sequence (first argument) cannot be null");
+                return;
+            }
             Sequence = sequence;
             sequence.AddDialog(Dialog);
         }
@@ -71,6 +76,11 @@ namespace Hybrasyl.Scripting
         /// <param name="luaExpr">A Lua expression to be evaluated.</param>
         public void AttachCallback(string luaExpr)
         {
+            if (string.IsNullOrEmpty(luaExpr))
+            {
+                GameLog.ScriptingWarning("AttachCallback: lua expression (first argument) was null or empty, ignoring");
+                return;
+            }
             Dialog.CallbackExpression = luaExpr;
         }
 

--- a/hybrasyl/Scripting/HybrasylDialogSequence.cs
+++ b/hybrasyl/Scripting/HybrasylDialogSequence.cs
@@ -40,24 +40,42 @@ namespace Hybrasyl.Scripting
         /// Add a dialog to this sequence (at the end of the sequence).
         /// </summary>
         /// <param name="scriptDialog">A dialog that will be added to the end of the sequence.</param>
-        public void AddDialog(HybrasylDialog scriptDialog) =>
+        public void AddDialog(HybrasylDialog scriptDialog)
+        {
+            if (scriptDialog is null)
+            {
+                GameLog.ScriptingError("AddDialog: script dialog (first argument) was null");
+                return;
+            }
             scriptDialog.AssociateDialogWithSequence(Sequence);
-        
+        }
         /// <summary>
         /// Add a display callback to the dialog sequence that will be evaluated before it is displayed.
         /// </summary>
         /// <param name="check">A lua scripting expression to be evaluated</param>
-        public void AddDisplayCallback(string check) =>
+        public void AddDisplayCallback(string check)
+        {
+            if (string.IsNullOrEmpty(check))
+            {
+                GameLog.ScriptingError("AddDisplayCallback: lua expression (first argument) is null or empty, ignoring");
+                return;
+            }
             Sequence.AddPreDisplayCallback(check);
-
+        }
         /// <summary>
         /// Add a menu check to the given dialog sequence. If this is a pursuit, the (boolean) expression will be evaluated before the
         /// dialog is added to the list of pursuits (NPC main menu). 
         /// </summary>
         /// <param name="check">The Lua expression to be evaluated as a check, which should return true or false.</param>
-        public void AddMenuCheckExpression(string check) =>
+        public void AddMenuCheckExpression(string check)
+        {
+            if (string.IsNullOrEmpty(check))
+            {
+                GameLog.ScriptingError("AddMenuCheckExpression: lua expression (first argument) is null or empty, ignoring");
+                return;
+            }
             Sequence.AddMenuCheckExpression(check);
-
+        }
         /// <summary>
         /// Set an NPC / creature display sprite for this sequence (will be used for all of its contained dialogs).
         /// This is the sprite that is displayed on the left hand side when a user views a dialog.
@@ -79,9 +97,16 @@ namespace Hybrasyl.Scripting
         /// listed from the main menu (e.g. is a pursuit).
         /// </summary>
         /// <param name="displayName"></param>
-        public void SetDisplayName(string displayName) =>
+        public void SetDisplayName(string displayName)
+        {
+            if (string.IsNullOrEmpty(displayName))
+            {
+                GameLog.ScriptingError("SetDisplayName: display name (first argument) is null or empty, setting to 'I-AM-ERROR'");
+                Sequence.DisplayName = "I-AM-ERROR";
+                return;
+            }
             Sequence.DisplayName = displayName;
-
+        }
         /// <summary>
         /// Associate a named script with this dialog sequence. This can be used to override processing or provide 
         /// more detailed custom scripting.
@@ -89,6 +114,11 @@ namespace Hybrasyl.Scripting
         /// <param name="scriptName">The name of a script known to Hybrasyl.</param>
         public void AssociateWithScript(string scriptName)
         {
+            if (string.IsNullOrEmpty(scriptName))
+            {
+                GameLog.ScriptingError("AssociateWithScript: script name (first argument) is null or empty, ignoring");
+                return;
+            }
             // Clear any existing script; the next access to Script will 
             // result in the object being evaluated from the passed name.
             // This handles several edge cases of a running script trying to

--- a/hybrasyl/Scripting/HybrasylUser.cs
+++ b/hybrasyl/Scripting/HybrasylUser.cs
@@ -255,6 +255,7 @@ namespace Hybrasyl.Scripting
                     legendtext = $"Wizard by oath of {oathGiver}";
                     break;
                 default:
+                    GameLog.ScriptingError("ChangeClass: {user} - unknown class (first argument) passed", User.Name);
                     throw new ArgumentException("Invalid class");
             }
             User.Legend.AddMark(icon, LegendColor.White, legendtext, "CLS");
@@ -320,7 +321,7 @@ namespace Hybrasyl.Scripting
             }
             catch (ArgumentException)
             {
-                GameLog.ErrorFormat("Legend mark: {0}: duplicate prefix {1}", User.Name, prefix);
+                GameLog.ScriptingError("AddLegendMark: {user} - duplicate prefix {prefix}", User.Name, prefix);
             }
             return false;
         }
@@ -361,6 +362,12 @@ namespace Hybrasyl.Scripting
         /// <returns>Boolean indicating whether or not the request was successful.</returns>
         public bool RequestDialog(string sequence, string invoker = "")
         {
+            if (string.IsNullOrEmpty(sequence))
+            {
+                GameLog.ScriptingError("RequestDialog: {user} - sequence (first argument) was null or empty", User.Name);
+                return false;
+            }
+
             DialogSequence sequenceObj = null;
             VisibleObject invokerObj = null;
 
@@ -379,7 +386,7 @@ namespace Hybrasyl.Scripting
             if (invokerObj != null && sequenceObj != null)
                 return Game.World.TryAsyncDialog(invokerObj, User, sequenceObj);
 
-            GameLog.Warning($"invoker {invoker} or sequence {sequence} not found");
+            GameLog.ScriptingWarning("RequestDialog: {user} - invoker {invoker} or sequence {sequence} not found", user, invoker, sequence);
             return false;
         }
         /// <summary>
@@ -390,6 +397,11 @@ namespace Hybrasyl.Scripting
         /// <param name="value">Dynamic (any type) value to be stored with the given name.</param>
         public void SetSessionCookie(string cookieName, dynamic value)
         {
+            if (string.IsNullOrEmpty(cookieName) || value is null)
+            {
+                GameLog.ScriptingError("SetSessionCookie: {user} - session cookie name (first argument) or value (second) was null or empty", User.Name);
+                return;
+            }
             try
             {
                 if (value.GetType() == typeof(string))
@@ -400,7 +412,7 @@ namespace Hybrasyl.Scripting
             }
             catch (Exception e)
             {
-                GameLog.WarningFormat("{0}: value could not be converted to string? {1}", User.Name, e.ToString());
+                GameLog.ScriptingError("SetSessionCookie: {user}: value (second argument) could not be converted to string? {error}", User.Name, e);
             }
         }
 
@@ -411,7 +423,11 @@ namespace Hybrasyl.Scripting
         /// <param name="cookieName">Name of the cookie</param>
         /// <param name="value">Dynamic (any type) value to be stored with the given name.</param>
         public void SetCookie(string cookieName, dynamic value)
-        { 
+        {
+            if (string.IsNullOrEmpty(cookieName) || value is null)
+            {
+                GameLog.ScriptingError("SetCookie: {user} - session cookie name (first argument) or value (second) was null or empty", User.Name);
+            }
             try
             {
                 if (value.GetType() == typeof(string))
@@ -422,7 +438,7 @@ namespace Hybrasyl.Scripting
             }
             catch (Exception e)
             {
-                GameLog.WarningFormat("{0}: value could not be converted to string? {1}", User.Name, e.ToString());
+                GameLog.ScriptingError("SetCookie: {user} - value (second argument) could not be converted to string? {exception}", User.Name, e.ToString());
             }
 
         }
@@ -432,42 +448,91 @@ namespace Hybrasyl.Scripting
         /// </summary>
         /// <param name="cookieName">The name of the cookie to fetch</param>
         /// <returns>string representation of the cookie value</returns>
-        public string GetSessionCookie(string cookieName) => User.GetSessionCookie(cookieName);
+        public string GetSessionCookie(string cookieName)
+        {
+            if (string.IsNullOrEmpty(cookieName))
+            {
+                GameLog.ScriptingError("GetSessionCookie: {user} - cookie name (first argument) was null or empty - returning nil", User.Name);
+                return null;
+            }
+            return User.GetSessionCookie(cookieName);
+        }
 
         /// <summary>
         /// Get the value of a cookie, if it exists.
         /// </summary>
         /// <param name="cookieName">The name of the cookie to fetch</param>
         /// <returns>string representation of the cookie value</returns>
-        public string GetCookie(string cookieName) => User.GetCookie(cookieName);
+        public string GetCookie(string cookieName)
+        {
+            if (string.IsNullOrEmpty(cookieName))
+            {
+                GameLog.ScriptingError("GetCookie: {user} - cookie name (first argument) was null or empty - returning nil", User.Name);
+                return null;
+            }
 
+            return User.GetCookie(cookieName);
+        }
         /// <summary>
         /// Check to see if a player has a specified cookie or not.
         /// </summary>
         /// <param name="cookieName">Cookie name to check</param>
         /// <returns>Boolean indicating whether or not the named cookie exists</returns>
-        public bool HasCookie(string cookieName) => User.HasCookie(cookieName);
+        public bool HasCookie(string cookieName)
+        {
+            if (string.IsNullOrEmpty(cookieName))
+            {
+                GameLog.ScriptingError("HasCookie: {user} - cookie name (first argument) was null or empty - returning false", User.Name);
+                return false;
+            }
 
+            return User.HasCookie(cookieName);
+        }
         /// <summary>
         /// Check to see if a player has a specified session cookie or not.
         /// </summary>
         /// <param name="cookieName">Cookie name to check</param>
         /// <returns>Boolean indicating whether or not the named cookie exists</returns>
-        public bool HasSessionCookie(string cookieName) => User.HasSessionCookie(cookieName);
+        public bool HasSessionCookie(string cookieName)
+        {
+            if (string.IsNullOrEmpty(cookieName))
+            {
+                GameLog.ScriptingError("HasSessionCookie: {user} - cookie name (first argument) was null or empty - returning false", User.Name);
+                return false;
+            }
+
+            return User.HasSessionCookie(cookieName);
+        }
 
         /// <summary>
         /// Permanently remove a cookie from a player.
         /// </summary>
         /// <param name="cookieName">The name of the cookie to be deleted.</param>
         /// <returns></returns>
-        public bool DeleteCookie(string cookieName) => User.DeleteCookie(cookieName);
-
+        public bool DeleteCookie(string cookieName)
+        {
+            if (string.IsNullOrEmpty(cookieName))
+            {
+                GameLog.ScriptingError("DeleteCookie: {user} cookie name (first argument) was null or empty - returning false", User.Name);
+                return false;
+            }
+            return User.DeleteCookie(cookieName);
+        }
         /// <summary>
         /// Permanently remove a session cookie from a player.
         /// </summary>
         /// <param name="cookieName">The name of the cookie to be deleted.</param>
         /// <returns></returns>
-        public bool DeleteSessionCookie(string cookieName) => User.DeleteSessionCookie(cookieName);
+        public bool DeleteSessionCookie(string cookieName)
+        {
+            if (string.IsNullOrEmpty(cookieName))
+            {
+                GameLog.ScriptingError("DeleteSessionCookie: {user} cookie name (first argument) was null or empty - returning false", User.Name);
+                return false;
+            }
+
+            return User.DeleteSessionCookie(cookieName);
+        }
 
         /// <summary>
         /// Display a special effect visible to players.
@@ -507,6 +572,11 @@ namespace Hybrasyl.Scripting
         /// <param name="y">Y coordinate target</param>
         public void Teleport(string location, int x, int y)
         {
+            if (string.IsNullOrEmpty(location))
+            {
+                GameLog.ScriptingError("Teleport: {user} - location name (first argument) was null or empty - aborting for safety", User.Name);
+                return;
+            }
             User.Teleport(location, (byte)x, (byte)y);
         }
 
@@ -569,8 +639,12 @@ namespace Hybrasyl.Scripting
         /// <returns>Boolean indicating whether or not it was successful (player may have full inventory, etc)</returns>
         public bool GiveItem(HybrasylWorldObject obj)
         {
-            if (obj.Obj is ItemObject)
+            if (obj.Obj is ItemObject || !(obj is null))
                 return User.AddItem(obj.Obj as ItemObject);
+            else
+            {
+                GameLog.ScriptingError("GiveItem: {user} - object (first argument) was either null, or not an item", User.Name);
+            }
             return false;
         }
 
@@ -583,6 +657,11 @@ namespace Hybrasyl.Scripting
         /// <returns>Boolean indicating whether or not the user was awarded XP.</returns>
         public bool CompletionAward(string cookie, uint xp = 0, string completionMessage = null)
         {
+            if (string.IsNullOrEmpty(cookie))
+            {
+                GameLog.ScriptingError("CompletionAward: {user} - cookie name (first parameter) cannot be null or empty - returning false", User.Name);
+                return false;
+            }
             if (User.HasCookie(cookie))
                 return false;
             User.SetCookie(cookie, new DateTimeOffset(DateTime.Now).ToUnixTimeSeconds().ToString());
@@ -601,6 +680,11 @@ namespace Hybrasyl.Scripting
         /// <returns>Boolean indicating whether or not it was successful (player may have full inventory, etc)</returns>
         public bool GiveItem(string name, int count = 1)
         {
+            if (string.IsNullOrEmpty(name))
+            {
+                GameLog.ScriptingError("GiveItem: {user}: item name (first parameter) was null or empty - returning false", User.Name);
+                return false;
+            }
             // Does the item exist?
             if (Game.World.WorldData.TryGetValueByIndex(name, out Xml.Item template))
             {
@@ -629,6 +713,7 @@ namespace Hybrasyl.Scripting
                     return success;
                 }
             }
+            GameLog.ScriptingError("GiveItem: {user} - item name {name} could not be found", User.Name, name);
             return false;
         }
 
@@ -640,6 +725,11 @@ namespace Hybrasyl.Scripting
         /// <returns></returns>
         public bool HasItem(string name, int count = 1)
         {
+            if (string.IsNullOrEmpty(name))
+            {
+                GameLog.ScriptingError("HasItem: {user} - item name (first parameter) was null or empty - returning false", User.Name);
+                return false;
+            }
             if (count == 1)
                 return User.Inventory.ContainsName(name);
             return User.Inventory.Contains(name, count);
@@ -653,15 +743,21 @@ namespace Hybrasyl.Scripting
         /// <returns>Boolean indicating whether or not it the item was successfully removed from the player's inventory.</returns>
         public bool TakeItem(string name, int count = 1)
         {
+            if (string.IsNullOrEmpty(name))
+            {
+                GameLog.ScriptingError("TakeItem: {user} - item name (first parameter) was null or empty - returning false", User.Name);
+                return false;
+            }
+
             if (User.Inventory.ContainsName(name))
             {
                 if (User.RemoveItem(name, (ushort)count))
                     return true;
                 else
-                    GameLog.ScriptingWarning("{Function}: User {User} removeitem failed for {item}", MethodInfo.GetCurrentMethod().Name, User.Name, name);
+                    GameLog.ScriptingWarning("TakeItem: {user} - failed for {item}", User.Name, name);
             }
             else
-                GameLog.ScriptingWarning("{Function}: User {User} doesn't have {item}", MethodInfo.GetCurrentMethod().Name, User.Name, name);
+                GameLog.ScriptingWarning("TakeItem: {user} doesn't have {item}", User.Name, name);
 
             return false;
         }
@@ -699,11 +795,15 @@ namespace Hybrasyl.Scripting
         /// <returns>Boolean indicating success</returns>
         public bool AddSkill(string skillname)
         {
-            if (Game.World.WorldData.TryGetValue(skillname, out Xml.Castable result))
+            if (string.IsNullOrEmpty(skillname))
+                GameLog.ScriptingError("AddSkill: {user} - skill name (first argument) cannot be null or empty");
+            else if (Game.World.WorldData.TryGetValue(skillname, out Xml.Castable result))
             {
                 User.AddSkill(result);
                 return true;
             }
+            else
+                GameLog.ScriptingError("AddSkill: {user} - skill {skill} not found", User.Name, skillname);
             return false;
         }
 
@@ -714,11 +814,15 @@ namespace Hybrasyl.Scripting
         /// <returns>Boolean indicating success</returns>
         public bool AddSpell(string spellname)
         {
-            if (Game.World.WorldData.TryGetValue(spellname, out Xml.Castable result))
+            if (string.IsNullOrEmpty(spellname))
+                GameLog.ScriptingError("AddSpell: {user} - spell name (first argument) cannot be null or empty");
+            else if (Game.World.WorldData.TryGetValue(spellname, out Xml.Castable result))
             {
                 User.AddSpell(result);
                 return true;
             }
+            else
+                GameLog.ScriptingError("AddSpell: {user} - spell {spell} not found", User.Name, spellname);
             return false;
         }
 
@@ -772,6 +876,7 @@ namespace Hybrasyl.Scripting
         /// <param name="message">The message.</param>
         public void Mail(string name, string subject, string message)
         {
+            GameLog.ScriptingFatal("Mail: not currently implemented");
         }
 
         /// Close any active dialogs for the current player.
@@ -790,6 +895,11 @@ namespace Hybrasyl.Scripting
         /// <param name="associateOverride">An object to associate with the dialog as the invokee.</param>
         public void StartSequence(string sequenceName, HybrasylWorldObject associateOverride = null)
         {
+            if (sequenceName == null)
+            {
+                GameLog.ScriptingError("StartSequence: {user} - sequence name (first argument) cannot be null or empty", User.Name);
+                return;
+            }
             DialogSequence sequence = null;
             VisibleObject associate = null;
             GameLog.DebugFormat("{0} starting sequence {1}", User.Name, sequenceName);
@@ -815,8 +925,8 @@ namespace Hybrasyl.Scripting
             // We should hopefully have a sequence now...
             if (sequence == null)
             {
-                GameLog.ErrorFormat("called from {0}: sequence name {1} cannot be found!",
-                    associate?.Name ?? "globalsequence", sequenceName);
+                GameLog.ScriptingError("StartSequence: {user} - called from {associate}: sequence name {seq} cannot be found!",
+                    User.Name, associate?.Name ?? "globalsequence", sequenceName);
                 // To be safe, terminate all dialog state
                 User.DialogState.EndDialog();
                 // If the user was previously talking to a merchant, and we can't find a sequence,
@@ -846,8 +956,6 @@ namespace Hybrasyl.Scripting
             User.DialogState.ActiveDialog.ShowTo(User, associate);
 
         }
-
-
 
         /// <summary>
         /// Calculate the Manhattan distance (distance between two points measured along axes at right angles) 

--- a/hybrasyl/Scripting/HybrasylUtility.cs
+++ b/hybrasyl/Scripting/HybrasylUtility.cs
@@ -29,7 +29,7 @@ namespace Hybrasyl.Scripting
     /// <summary>
     /// A variety of utility functions for scripts that are statically accessible from a global `utility` object.
     /// </summary>
-    
+
     [MoonSharpUserData]
     public static class HybrasylUtility
     {
@@ -61,6 +61,22 @@ namespace Hybrasyl.Scripting
         /// <param name="t1"></param>
         /// <param name="t2"></param>
         /// <returns></returns>
-        public static long HoursBetweenUnixTimes(string t1, string t2) => (Convert.ToInt64(t2) - Convert.ToInt64(t1)) / 3600;
+        public static long HoursBetweenUnixTimes(string t1, string t2)
+        {
+            if (string.IsNullOrEmpty(t1) || string.IsNullOrEmpty(t2))
+            {
+                GameLog.ScriptingError("HoursBetweenUnixTimes: t1 (first argument) or t2 (second argument) was null or empty, returning 0");
+                return 0;
+            }
+            try
+            {
+                return (Convert.ToInt64(t2) - Convert.ToInt64(t1)) / 3600;
+            }
+            catch (Exception e)
+            {
+                GameLog.ScriptingError("HoursBetweenUnixTimes: Exception occurred doing time conversion, returning 0 - {exception}", e);
+                return 0;
+            }
+        }
     }
 }

--- a/hybrasyl/Scripting/HybrasylWorld.cs
+++ b/hybrasyl/Scripting/HybrasylWorld.cs
@@ -26,6 +26,7 @@ using System;
 using System.Collections;
 using System.Collections.Specialized;
 using System.Reflection;
+using System.Diagnostics;
 
 namespace Hybrasyl.Scripting
 {
@@ -47,8 +48,14 @@ namespace Hybrasyl.Scripting
         /// </summary>
         /// <param name="option">The option text</param>
         /// <param name="luaExpr">The lua expression to be evaluated when the option is selected by a player</param>
-        public void AddOption(string option, string luaExpr = null) => Options.Add(option, luaExpr);
-
+        public void AddOption(string option, string luaExpr = null)
+        {
+            if (string.IsNullOrEmpty(option) || string.IsNullOrEmpty(luaExpr))
+            {
+                GameLog.ScriptingError("AddOption: either option (first argument) or lua expression (second argument) was null or empty");
+            }
+            Options.Add(option, luaExpr);
+        }
         /// <summary>
         /// Add a dialog option which will fire a JumpDialog when selected by a player.
         /// </summary>
@@ -56,10 +63,14 @@ namespace Hybrasyl.Scripting
         /// <param name="nextDialog">The JumpDialog that will be used by this option</param>
         public void AddOption(string option, HybrasylDialog nextDialog)
         {
+            if (string.IsNullOrEmpty(option) || nextDialog is null)
+            {
+                GameLog.ScriptingError($"AddOption: for options set, option (first argument) or dialog (second argument) was null or empty");
+            }
             if (nextDialog.DialogType == typeof(JumpDialog))
                 Options.Add(option, nextDialog);
             else
-                GameLog.Error($"Dialog option {option}: unsupported dialog type {nextDialog.DialogType.Name}");
+                GameLog.ScriptingError($"AddOption: Dialog option {option}: dialog must be JumpDialog, but was a {nextDialog.DialogType.Name}, ignored");
         }
         /// <summary>
         /// Add a dialog option that will start a new sequence when selected by a player.
@@ -101,6 +112,8 @@ namespace Hybrasyl.Scripting
         /// </summary>
         public string CurrentInGameAge => HybrasylTime.CurrentAgeName;
 
+        public string CurrentInGameSeason => HybrasylTime.CurrentSeason;
+
         /// <summary>
         /// Return the current in-game time.
         /// </summary>
@@ -139,6 +152,12 @@ namespace Hybrasyl.Scripting
         /// <returns>The constructed dialog sequence</returns>
         public HybrasylDialogSequence NewDialogSequence(string sequenceName, params object[] list)
         {
+            if (string.IsNullOrEmpty(sequenceName))
+            {
+                GameLog.ScriptingError($"NewDialogSequence: Sequence name (first argument) was null / empty");
+                return null;
+            }
+
             var dialogSequence = new HybrasylDialogSequence(sequenceName);
             foreach (var entry in list)
             {
@@ -150,7 +169,7 @@ namespace Hybrasyl.Scripting
                 }
                 else
                 {
-                    GameLog.Error($"Unknown parameter type {entry.GetType()} passed to NewDialogSequence, ignored");
+                    GameLog.ScriptingError($"NewDialogSequence: Unknown argument of type {entry.GetType()} was passed for a dialog - ignored");
                 }
             }
             return dialogSequence;
@@ -164,6 +183,12 @@ namespace Hybrasyl.Scripting
         /// <returns>The constructed dialog</returns>
         public HybrasylDialog NewDialog(string displayText, string callback = null)
         {
+            if (string.IsNullOrEmpty(displayText))
+            {
+                GameLog.ScriptingError($"NewDialog: Sequence name (first argument) was null / empty");
+                return null;
+            }
+
             var dialog = new SimpleDialog(displayText);
             dialog.SetCallbackHandler(callback);
             return new HybrasylDialog(dialog);
@@ -177,9 +202,20 @@ namespace Hybrasyl.Scripting
         /// <returns>The constructed dialog seqeunce</returns>
         public HybrasylDialogSequence NewSimpleDialogSequence(string sequenceName, params string[] textList)
         {
+            if (string.IsNullOrEmpty(sequenceName))
+            {
+                GameLog.ScriptingError($"NewSimpleDialogSequence: Sequence name (first argument) was null / empty");
+                return null;
+            }
+
             var sequence = new DialogSequence(sequenceName);
             foreach (var entry in textList)
             {
+                if (string.IsNullOrEmpty(entry))
+                {
+                    GameLog.ScriptingWarning("NewSimpleDialogSequence: encountered empty / null dialog text, ignoring");
+                    continue;
+                }
                 sequence.AddDialog(new SimpleDialog(entry));
             }
             return new HybrasylDialogSequence(sequence);
@@ -197,6 +233,12 @@ namespace Hybrasyl.Scripting
         public HybrasylDialogSequence NewTextAndJumpDialog(string simpleDialog, string jumpTarget, string callback = "", string name = null)
         {
             DialogSequence sequence;
+            if (string.IsNullOrEmpty(simpleDialog) || string.IsNullOrEmpty(jumpTarget))
+            {
+                GameLog.ScriptingError("NewTextAndJumpDialog: text (first argument) or jump target (second argument) cannot be null or empty");
+                return null;
+            }
+
             if (name == null)
                 sequence = new DialogSequence(Guid.NewGuid().ToString());
             else
@@ -222,6 +264,13 @@ namespace Hybrasyl.Scripting
         public HybrasylDialogSequence NewEndSequence(string simpleDialog, string callback = "", string name = null)
         {
             DialogSequence sequence;
+
+            if (string.IsNullOrEmpty(simpleDialog))
+            {
+                GameLog.ScriptingError("NewEndSequence: Dialog text (first argument) cannot be null or empty");
+                return null;
+            }
+
             if (name == null)
                 sequence = new DialogSequence(Guid.NewGuid().ToString());
             else
@@ -248,6 +297,11 @@ namespace Hybrasyl.Scripting
         /// <returns>The constructed dialog</returns>    
         public HybrasylDialog NewTextDialog(string displayText, string topCaption, string bottomCaption, int inputLength = 254, string callback="", string handler="")
         {
+            if (string.IsNullOrEmpty(displayText))
+            {
+                GameLog.Error("NewTextDialog: display text (first argument) was null");
+                return null;
+            }
             var dialog = new TextDialog(displayText, topCaption, bottomCaption, inputLength);
             dialog.SetInputHandler(handler);
             dialog.SetCallbackHandler(callback);
@@ -264,6 +318,18 @@ namespace Hybrasyl.Scripting
         /// <returns>The constructed dialog</returns>
         public HybrasylDialog NewOptionsDialog(string displayText, HybrasylDialogOptions dialogOptions, string callback="", string handler = "")
         {
+            if (string.IsNullOrEmpty(displayText))
+            {
+                GameLog.ScriptingError("NewOptionsDialog: display text (first argument) cannot be null or empty");
+                return null;
+            }
+
+            if (dialogOptions is null || dialogOptions.Options.Count == 0)
+            {
+                GameLog.ScriptingError("NewOptionsDialog: dialogOptions (second or greater argument(s)) null, or had no options");
+                return null;
+            }
+
             var dialog = new OptionsDialog(displayText);
             foreach (DictionaryEntry entry in dialogOptions.Options)
             {
@@ -277,7 +343,8 @@ namespace Hybrasyl.Scripting
                         // Dialog jump
                         dialog.AddDialogOption(entry.Key as string, hd.Dialog as JumpDialog);
                     else
-                        GameLog.Error("Unknown dialog type {0} in NewOptionsDialog - only JumpDialog is allowed currently");
+                        GameLog.ScriptingError("NewOptionsDialog: one or more passed option(s) uses type {type} - only jump dialogs are allowed currently", 
+                            entry.Value.GetType().Name);
                 }
                 else if (entry.Value is null)
                     // This is JUST an option, with no callback or jump dialog. The dialog handler will process the option itself.
@@ -288,10 +355,12 @@ namespace Hybrasyl.Scripting
                     dialog.AddDialogOption(entry.Key as string, hds.Sequence);
                 }
                 else
-                    GameLog.Error($"Unknown type {entry.Value.GetType().Name} passed as argument to NewOptionsDialog call");
+                    GameLog.ScriptingError("NewOptionsDialog: one or more passed option(s) was an unknown type {type} - this will not work",
+                        entry.Value.GetType().Name);
             }
             if (dialog.OptionCount == 0)
-                GameLog.Warning($"OptionsDialog with no options created. This dialog WILL NOT render. DisplayText follows: {displayText}");
+                GameLog.ScriptingError("NewOptionsDialog: no options were passed or created. This dialog WILL NOT render. DisplayText follows: {displayText}",
+                    displayText);
             dialog.SetInputHandler(handler);
             dialog.SetCallbackHandler(callback);
             return new HybrasylDialog(dialog);
@@ -305,6 +374,10 @@ namespace Hybrasyl.Scripting
         /// <returns>The constructed dialog</returns>
         public HybrasylDialog NewFunctionDialog(string luaExpr)
         {
+            if (string.IsNullOrEmpty(luaExpr))
+            {
+                GameLog.ScriptingError("NewFunctionDialog: lua expression (first argument) cannot be null or empty");
+            }
             return new HybrasylDialog(new FunctionDialog(luaExpr));
         }
 
@@ -316,6 +389,11 @@ namespace Hybrasyl.Scripting
         /// <returns>The constructed dialog</returns>
         public HybrasylDialog NewJumpDialog(string targetSequence, string callbackExpression = null)
         {
+            if (string.IsNullOrEmpty(targetSequence))
+            {
+                GameLog.ScriptingError("NewJumpDialog: target sequence (first argument) cannot be null or empty");
+                return null;
+            }
             var dialog = new JumpDialog(targetSequence);
             if (!string.IsNullOrEmpty(callbackExpression))
                 dialog.SetCallbackHandler(callbackExpression);
@@ -340,6 +418,8 @@ namespace Hybrasyl.Scripting
         /// <param name="globalSequence">The dialog sequence to be registered as a global seqeunce.</param>
         public void RegisterGlobalSequence(HybrasylDialogSequence globalSequence)
         {
+            if (globalSequence is null || globalSequence.Sequence.Dialogs.Count == 0)
+                GameLog.ScriptingError("RegisterGlobalSequence: sequence (first argument) was null, or the sequence contained no dialogs");
             Game.World.RegisterGlobalSequence(globalSequence.Sequence);
         }
     }

--- a/hybrasyl/Scripting/Script.cs
+++ b/hybrasyl/Scripting/Script.cs
@@ -22,7 +22,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Hybrasyl.Enums;
 using Hybrasyl.Objects;
 using MoonSharp.Interpreter;
@@ -49,10 +51,18 @@ namespace Hybrasyl.Scripting
         public void Error(string message) => Log.Error("{ScriptName} : {Message}", ScriptName, message);
     }
 
+    public struct LuaException
+    {
+        public string Filename;
+        public int LineNumber;
+        public string Error;
+    };
+
     public class Script
     {
-
+        static Regex LuaRegex = new Regex(@"(.*):\(([0-9]*),([0-9]*)-([0-9]*)\): (.*)$");
         public string RawSource { get; set; }
+
         public string Name { get; set; }
         public string FullPath { get; private set; }
         public string FileName => Path.GetFileName(FullPath);
@@ -97,6 +107,9 @@ namespace Hybrasyl.Scripting
 
         public void AssociateScriptWithObject(WorldObject obj)
         {
+            if (Associate?.Obj?.Id == obj.Id)
+                return;
+
             Associate = new HybrasylWorldObject(obj);
             if (obj is VisibleObject)
             { 
@@ -140,6 +153,66 @@ namespace Hybrasyl.Scripting
             return UserData.Create(obj); 
         }
 
+        private static LuaException ParseException(string decoratedMessage)
+        {
+            var matches = LuaRegex.Match(decoratedMessage);
+            var ret = new LuaException();
+            if (matches.Success && matches.Groups.Count == 6)
+            {
+                ret.Filename = Path.GetFileName(matches.Groups[1].Value);
+                ret.LineNumber = int.Parse(matches.Groups[2].Value);
+                ret.Error = matches.Groups[5].Value;
+            }
+            else
+                ret.Error = decoratedMessage;
+            return ret;
+        }
+        
+        private string ExtractLuaSource(int linenumber)
+        {
+            var lines = RawSource.Split('\n').ToList();
+            var lua = $"## {lines[linenumber - 2]}\n## --->{lines[linenumber-1]}\n";
+            if (linenumber < lines.Count)
+                lua = $"{lua}## {lines[linenumber]}";
+            return lua;
+        }
+
+        private string HumanizeException(Exception ex)
+        {
+            var lines = RawSource.Split('\n').ToList();
+            var summary = string.Empty;
+
+            if (ex is InterpreterException ie)
+            {
+                // Get information from decorated message. CallStack is only available for
+                // certain lua exceptions; decorated message / innerexception always has what
+                // is needed.
+                var e = ParseException(ie.DecoratedMessage);
+                if (!string.IsNullOrEmpty(e.Filename))
+                    summary = $"Line {e.LineNumber}: {e.Error}\n{ExtractLuaSource(e.LineNumber)}";
+                else
+                    summary = $"Could not be parsed, raw message follows {ie.DecoratedMessage}";
+                if (ie is SyntaxErrorException)
+                {
+                    return $"\nSyntax error: {summary}";
+                }
+                if (ie is ScriptRuntimeException)
+                    return $"\nScripting runtime error: {summary}";
+                if (ie is DynamicExpressionException)
+                    return $"\nLua type error: {summary}";
+                else
+                    return $"\nInternal error from Lua code: STACK: {summary}\nERR: {ie.DecoratedMessage}";
+            }
+            else
+            {
+                var retstr = string.Empty;
+                retstr = $"\nC# exception, perhaps caused by Lua script code: STACK: {ex.StackTrace}\n ERR:{ex.Message}";
+                if (ex.InnerException != null)
+                    retstr = $"{retstr}\nINNER STACK TRACE: {ex.InnerException.StackTrace}\n INNER ERR: {ex.InnerException.Message}";
+                return retstr;
+            }
+        }
+
         /// <summary>
         /// Check to see if a script implements a given function.
         /// </summary>
@@ -179,18 +252,24 @@ namespace Hybrasyl.Scripting
                 Compiled.Globals.Set("world", UserData.Create(Processor.World));
                 Compiled.Globals.Set("logger", UserData.Create(new ScriptLogger(Name)));
                 Compiled.Globals.Set("this_script", DynValue.NewString(Name));
+                // Load file into RawSource so we have access to it later
+                RawSource = File.ReadAllText(FullPath);
                 Compiled.DoFile(FullPath);
                 if (onLoad)
-                    ExecuteFunction("OnLoad");               
+                {
+                    GameLog.ScriptingInfo($"Loading: {Path.GetFileName(FullPath)}");
+                    ExecuteFunction("OnLoad");
+                }
             }
-            catch (Exception ex) when (ex is InterpreterException)
+            catch (Exception ex) 
             {
-                GameLog.ScriptingError("{Function}: Error executing script {FileName}: {Message}",
-                                MethodBase.GetCurrentMethod().Name, FileName, 
-                                (ex as InterpreterException).DecoratedMessage);
+                var error_msg = HumanizeException(ex);
+                GameLog.ScriptingError("Run: Error executing script {FileName} (associate {assoc}): {Message}",
+                                  FileName, Associate?.Name ?? "none", error_msg);
+                
                 Disabled = true;
                 CompilationError = ex.ToString();
-                LastRuntimeError = (ex as InterpreterException).DecoratedMessage;
+                LastRuntimeError = error_msg;
                 return false;
             }
 
@@ -242,14 +321,14 @@ namespace Hybrasyl.Scripting
                 // We pass Compiled.Globals here to make sure that the updated table (with new variables) makes it over
                 LastReturnValue = Compiled.DoString(expr, Compiled.Globals);
             }
-            catch (Exception ex) when (ex is InterpreterException)
+            catch (Exception ex) 
             {
-                GameLog.ScriptingError("{Function}: Error executing expression {expr} in {FileName} (invoker {Invoker}): {Message}",
-                    MethodBase.GetCurrentMethod().Name, expr, FileName, invoker.Name,
-                    (ex as InterpreterException).DecoratedMessage);
+                var error_msg = HumanizeException(ex);
+                GameLog.ScriptingError("Execute: Error executing expression {expr} in {FileName} (associate {associate}, invoker {invoker}, source {source}): {Message}",
+                    expr, FileName, Associate?.Name ?? "none", invoker?.Name ?? "none", source?.Name ?? "none", error_msg);
                 //Disabled = true;
                 CompilationError = ex.ToString();
-                LastRuntimeError = (ex as InterpreterException).DecoratedMessage;
+                LastRuntimeError = error_msg;
                 return false;
             }
             return true;
@@ -264,13 +343,14 @@ namespace Hybrasyl.Scripting
             {
                 Compiled.Globals["utility"] = typeof(HybrasylUtility);
                 Compiled.Globals.Set("invoker", GetUserDataValue(invoker));
+                Compiled.Globals.Set("parent", GetUserDataValue(invoker));
                 return Compiled.DoString(expr);
             }
-            catch (Exception ex) when (ex is InterpreterException)
+            catch (Exception ex)
             {
-                GameLog.ScriptingError("{Function}: Error executing expression: {expr} in {FileName} (invoker {Invoker}): {Message}",
-                    MethodBase.GetCurrentMethod().Name, expr, FileName, invoker.Name,
-                    (ex as InterpreterException).DecoratedMessage);
+                var error_msg = HumanizeException(ex);
+                GameLog.ScriptingError("Execute: Error executing expression {expr} in {FileName} (associate {associate}, invoker {invoker}): {Message}",
+                    expr, FileName, Associate?.Name ?? "none", invoker?.Name ?? "none", error_msg);
                  //Disabled = true;
                 CompilationError = ex.ToString();
                 return DynValue.Nil;
@@ -294,15 +374,19 @@ namespace Hybrasyl.Scripting
                     Compiled.Call(Compiled.Globals[functionName]);
                 }
                 else
+                {
+                    //GameLog.ScriptingWarning("ExecuteFunction: function {fn} in {FileName} did not exist",
+                    //    functionName, FileName);
                     return false;
+                }
             }
-            catch (Exception ex) when (ex is InterpreterException)
+            catch (Exception ex) 
             {
-                GameLog.ScriptingError("{Function}: Error executing function {ScriptFunction} in {FileName} (invoker {Invoker}): {Message}",
-                    MethodBase.GetCurrentMethod().Name, functionName, FileName, invoker.Name,
-                    (ex as InterpreterException).DecoratedMessage);
+                var error_msg = HumanizeException(ex);
+                GameLog.ScriptingError("ExecuteFunction: Error executing function {fn} in {FileName} (associate {associate}, invoker {invoker}, item {item}): {Message}",
+                    functionName, FileName, Associate?.Name ?? "none", invoker?.Name ?? "none", scriptItem?.Name ?? "none", error_msg);
                 //Disabled = true;
-                CompilationError = ex.ToString();
+                CompilationError = error_msg;
                 return false;
             }
             return true;
@@ -323,17 +407,17 @@ namespace Hybrasyl.Scripting
                 }
                 else
                 {
-                    GameLog.ScriptingError("{Function}: function {ScriptFunction} in {FileName} did not exist?", MethodBase.GetCurrentMethod().Name,
-                        functionName, FileName);
+                    //GameLog.ScriptingWarning("ExecuteFunction: function {fn} in {FileName} did not exist",
+                    //    functionName, FileName);
                     return false;
                 }
             }
-            catch (Exception ex) when (ex is InterpreterException)
+            catch (Exception ex)
             {
-                GameLog.ScriptingError("{Function}: Error executing script function {ScriptFunction} in {FileName} (invoker {Invoker}): {Message}",
-                    MethodBase.GetCurrentMethod().Name, functionName, invoker.Name, FileName,
-                    (ex as InterpreterException).DecoratedMessage);
-                CompilationError = ex.ToString();
+                var error_msg = HumanizeException(ex);
+                GameLog.ScriptingError("ExecuteFunction: Error executing function {fn} in {FileName} (associate {associate}, invoker {invoker}): {Message}",
+                    functionName, FileName, Associate?.Name ?? "none", invoker?.Name ?? "none", error_msg);
+                CompilationError = error_msg;
                 return false;
             }
 
@@ -351,17 +435,34 @@ namespace Hybrasyl.Scripting
                 if (HasFunction(functionName))
                 {
                     Compiled.Globals["utility"] = typeof(HybrasylUtility);
+                    // Provide extra information when running spawn/load to aid in debugging
+                    if (functionName == "OnSpawn" || functionName == "OnLoad")
+                    {
+                        string assoc = null;
+                        if (Associate != null)
+                        {
+                            assoc = $"{Associate.Type}";
+                            if (!string.IsNullOrEmpty(Associate.Name))
+                                assoc = $"{assoc} {Associate.Name}";
+                            assoc = $"{assoc}: {Associate.LocationDescription}";
+                        }
+                        GameLog.ScriptingInfo($"{FileName}: (associate is {assoc ?? "none"}), executing {functionName}");
+                    }
                     Compiled.Call(Compiled.Globals[functionName]);
                 }
                 else
+                {
+                    //GameLog.ScriptingWarning("ExecuteFunction: function {fn} in {FileName} did not exist",
+                    //    functionName, FileName);
                     return false;
+                }
             }
-            catch (Exception ex) when (ex is InterpreterException)
+            catch (Exception ex)
             {
-                GameLog.ScriptingError("{Function}: Error executing script function {ScriptFunction} in {FileName}: {Message}",
-                    MethodBase.GetCurrentMethod().Name, functionName, FileName,
-                    (ex as InterpreterException).DecoratedMessage);
-                CompilationError = ex.ToString();
+                var error_msg = HumanizeException(ex);
+                GameLog.ScriptingError("ExecuteFunction: Error executing function {fn} in {FileName} (associate {associate}): {Message}",
+                    functionName, FileName, Associate?.Name ?? "none", error_msg);
+                CompilationError = error_msg;
                 return false;
             }
 

--- a/hybrasyl/Time.cs
+++ b/hybrasyl/Time.cs
@@ -148,6 +148,8 @@ namespace Hybrasyl
 
         public static string CurrentAgeName => CurrentAge.Name;
 
+        public static string CurrentSeason => Now.Season;
+
         public static Xml.HybrasylAge CurrentAge
         {
             get

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -337,7 +337,7 @@ namespace Hybrasyl
                     var map = new Map(newMap, this);
                     if (!WorldData.SetWithIndex(map.Id, map, map.Name))
                         GameLog.ErrorFormat("SetWithIndex fail for {map.Name}..?");
-                    GameLog.InfoFormat("Maps: Loaded {0}", map.Name);
+                    GameLog.Info("Maps: Loaded {filename} ({mapname})", Path.GetFileName(xml), map.Name);
                 }
                 catch (Exception e)
                 {
@@ -4109,7 +4109,7 @@ namespace Hybrasyl
                 catch (InvalidOperationException e)
                 {
                     if (!MessageQueue.IsCompleted)
-                        GameLog.Error($"QUEUE CONSUMER: EXCEPTION RAISED: {e}");
+                        GameLog.Error($"QUEUE CONSUMER: EXCEPTION RAISED: {e}", e);
                     continue;
                 }
 


### PR DESCRIPTION
Significant refactoring to scripting logging, improve error reporting - Lua will now give detailed reports about startup / execution errors, which should help with scripting work and general debugging. The lines around the error in the script are printed, and the line itself where the error happened is indicated with an arrow:

Runtime error example:

```
2020-08-13 10:57:32.961 -07:00 [ERR] ExecuteFunction: Error executing function OnSpawn in Cian.lua (associate Cian):
Scripting runtime error: Line 73: cannot access field StoreEphemeral of userdata<Hybrasyl.Scripting.HybrasylWorldObject>
##       needed_item = littlebit_items[math.random(#littlebit_items)]
## --->      associate.StoreEphemeral('lb-neededitem', needed_item)
##       associate.StoreEphemeral('lb-changetime', utility.GetUnixTime())
```

Syntax error example:

```
2020-08-13 10:57:31.931 -07:00 [ERR] Run: Error executing script TrainingDummy.lua (associate none):
Syntax error: Line 18: unexpected symbol near 'then'
##    end
## --->   if (((( then
##    associate.Say(source.Name .. ", you healed me for " .. heal)
```

Add startup check for Hybrasyl server version (will print notice if out of date). This will check https://www.hybrasyl.com/builds/latest.json for a file that is automatically updated when new artifacts are built.

```
2020-08-13 10:57:41.246 -07:00 [WRN] THIS VERSION OF HYBRASYL IS OUT OF DATE
2020-08-13 10:57:41.248 -07:00 [WRN] You have ff516468 but d34db33f is available as of Thu Aug 13 10:23:48 PDT 2020
2020-08-13 10:57:41.248 -07:00 [WRN] You can download the new version at https://www.hybrasyl.com/builds/ .
```


Add flag for identifiable items - requested by @Caeldeth as it is a needed feature to support item parity

## How to QA
Run a script with errors

## Impacted Areas in Hybrasyl
XML, script logging
