### PR TITLE
Clean up build process / version information retrieval

### DIFF
--- a/hybrasyl/Hybrasyl.csproj
+++ b/hybrasyl/Hybrasyl.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <MSBuildGitHashCommand>git log HEAD -1</MSBuildGitHashCommand>
+    <MSBuildGitHashCommand>git show-ref -s HEAD </MSBuildGitHashCommand>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/hybrasyl/Messaging/Info.cs
+++ b/hybrasyl/Messaging/Info.cs
@@ -71,7 +71,7 @@ namespace Hybrasyl.Messaging
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
-            return Success($"Hybrasyl {Game.Assemblyinfo.Version}\n\n{Game.Assemblyinfo.GitHash.Replace(';','\n')}\n\n(C) 2020 ERISCO, LLC", MessageTypes.SLATE_WITH_SCROLLBAR);
+            return Success($"Hybrasyl {Game.Assemblyinfo.Version}\n\nRunning commit {(string.IsNullOrEmpty(Game.GitCommit) ? "unknown" : Game.GitCommit)}:\n\n{Game.CommitLog}\n\n(C) 2020 ERISCO, LLC", MessageTypes.SLATE_WITH_SCROLLBAR);
         }
     }
 


### PR DESCRIPTION
This fixes an occasional problem with builds caused by our attempt to embed the last commit log from HEAD into the build for the purposes of showing it to the user in motd and via `/version`. This cleans that up, and uses an async to fetch commit information from GitHub on server startup instead.
