### PR TITLE
Add Sentry for error reporting; simplify access checks; fix OnHear bugs

### DIFF
--- a/XML/XML.csproj
+++ b/XML/XML.csproj
@@ -36,19 +36,19 @@
   </ItemGroup> 
  
   <ItemGroup>
-    <PackageReference Include="docfx" Version="2.53.1" />
-    <PackageReference Include="docfx.console" Version="2.53.1">
+    <PackageReference Include="docfx" Version="2.56.2" />
+    <PackageReference Include="docfx.console" Version="2.56.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.1" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
   </ItemGroup>
 

--- a/XML/XSD/Extensions.cs
+++ b/XML/XSD/Extensions.cs
@@ -493,3 +493,30 @@ namespace Hybrasyl.Xml
     }
 }
 
+namespace Hybrasyl.Xml
+{
+    public partial class Access
+    {
+        private List<string> _privilegedUsers = new List<String>();
+
+        public List<string> PrivilegedUsers
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(Privileged))
+                  foreach (var p in Privileged.Trim().Split(' '))
+                    _privilegedUsers.Add(p.Trim().ToLower());
+                return _privilegedUsers;
+            }
+        }
+
+        public bool IsPrivileged(string user)
+        {
+            if (PrivilegedUsers.Count > 0)
+                return PrivilegedUsers.Contains(user.ToLower()) || PrivilegedUsers.Contains("*");
+            return false;
+        }
+
+    }
+}
+

--- a/XML/XSD/Objects/ApiEndpoints.cs
+++ b/XML/XSD/Objects/ApiEndpoints.cs
@@ -31,6 +31,7 @@ public partial class ApiEndpoints
     private TargetUrl _remoteAdminHost;
     private TargetUrl _encryptionEndpoint;
     private TargetUrl _validationEndpoint;
+    private TargetUrl _sentry;
     private static XmlSerializer _serializer;
     #endregion
     
@@ -85,6 +86,18 @@ public partial class ApiEndpoints
         set
         {
             _validationEndpoint = value;
+        }
+    }
+    
+    public TargetUrl Sentry
+    {
+        get
+        {
+            return _sentry;
+        }
+        set
+        {
+            _sentry = value;
         }
     }
     

--- a/XML/XSD/ServerConfig.xsd
+++ b/XML/XSD/ServerConfig.xsd
@@ -64,6 +64,7 @@
       <xs:element name="RemoteAdminHost" type="hyb:TargetUrl" />
       <xs:element name="EncryptionEndpoint" type="hyb:TargetUrl" maxOccurs="1" minOccurs="0" />
       <xs:element name="ValidationEndpoint" type="hyb:TargetUrl" minOccurs="0" maxOccurs="1" />
+      <xs:element name="Sentry" minOccurs="0" maxOccurs="1" type="hyb:TargetUrl"/>
     </xs:sequence>
   </xs:complexType>
 

--- a/hybrasyl/Board.cs
+++ b/hybrasyl/Board.cs
@@ -236,7 +236,7 @@ namespace Hybrasyl
         {
             var checkname = charName.ToLower();
 
-            if (ModeratorList.Contains(checkname))
+            if (ModeratorList.Contains(checkname) || ModeratorList.Contains("*"))
                 return true;
 
             if (BlockList.Contains(checkname))

--- a/hybrasyl/Client.cs
+++ b/hybrasyl/Client.cs
@@ -129,8 +129,9 @@ namespace Hybrasyl
                 WorkSocket.Shutdown(SocketShutdown.Both);
                 WorkSocket.Close();
             }
-            catch (Exception)
+            catch (Exception e)
             {
+                Game.ReportException(e);
                 WorkSocket.Close();
             }
 
@@ -508,19 +509,22 @@ namespace Hybrasyl
                             await Task.Delay(transmitDelay);
                         Socket.BeginSend(socketbuf, 0, socketbuf.Length, 0, SendCallback, ClientState);
                     }
-                    catch (ObjectDisposedException)
+                    catch (ObjectDisposedException e)
                     {
+                        Game.ReportException(e);
                         ClientState.Dispose();
                     }
                 });
             }
-            catch (ObjectDisposedException)
+            catch (ObjectDisposedException e)
             {
                 // Socket is gone, peace out
+                Game.ReportException(e);
                 ClientState.Dispose();
             }
             catch (Exception e)
             {
+                Game.ReportException(e);
                 GameLog.Error($"HALP: {e}");
             }
         }
@@ -578,12 +582,14 @@ namespace Hybrasyl
                         }
                         catch (Exception e)
                         {
+                            Game.ReportException(e);
                             GameLog.ErrorFormat("EXCEPTION IN HANDLING: 0x{0:X2}: {1}", packet.Opcode, e);
                         }
                     }
                 }
                 catch (Exception e)
                 {
+                    Game.ReportException(e);
                     Console.WriteLine(e);
                     throw;
                 }
@@ -617,11 +623,13 @@ namespace Hybrasyl
             }
             catch (SocketException e)
             {
+                Game.ReportException(e);
                 GameLog.Error($"Error Code: {e.ErrorCode}, {e.Message}");
                 state.WorkSocket.Close();
             }
-            catch (ObjectDisposedException)
+            catch (ObjectDisposedException e)
             {
+                Game.ReportException(e);
                 //client.Disconnect();
                 GameLog.Error($"ObjectDisposedException");
                 state.WorkSocket.Close();

--- a/hybrasyl/Connection.cs
+++ b/hybrasyl/Connection.cs
@@ -74,8 +74,9 @@ namespace Hybrasyl
                 {
                     World.ControlMessageQueue.Add(new HybrasylControlMessage(ControlOpcodes.CleanupUser, client.ConnectionId));
                 }
-                catch (InvalidOperationException)
+                catch (InvalidOperationException e)
                 {
+                    Game.ReportException(e);
                     if (!World.ControlMessageQueue.IsCompleted)
                         GameLog.ErrorFormat("Connection {id}: DeregisterClient failed", client.ConnectionId);
                 }
@@ -109,6 +110,7 @@ namespace Hybrasyl
             }
             catch (Exception e)
             {
+                Game.ReportException(e);
                 GameLog.Error("RequestEncryptionKey failure: {e}", e);
                 key = Encoding.ASCII.GetBytes("NOTVALID!");
             }
@@ -140,6 +142,7 @@ namespace Hybrasyl
             }
             catch (Exception e)
             {
+                Game.ReportException(e);
                 GameLog.Error("ValidateEncryptionKey failure: {e}", e);
                 return false;
             }

--- a/hybrasyl/CreatureStatus.cs
+++ b/hybrasyl/CreatureStatus.cs
@@ -391,7 +391,8 @@ namespace Hybrasyl
                 methodInfo.Invoke(invokee,null);
             }
             catch (Exception e)
-            { 
+            {
+                Game.ReportException(e);
                 GameLog.Error("Exception processing status handler: {exception}", e);
 
             }

--- a/hybrasyl/Dialogs.cs
+++ b/hybrasyl/Dialogs.cs
@@ -325,6 +325,7 @@ namespace Hybrasyl
                     }
                     catch (Exception ex)
                     {
+                        Game.ReportException(ex);
                         GameLog.ScriptingError(ex, "{Function}: callback unhandled exception", MethodInfo.GetCurrentMethod().Name);
                         target.ClearDialogState();
                     }

--- a/hybrasyl/Hybrasyl.csproj
+++ b/hybrasyl/Hybrasyl.csproj
@@ -44,26 +44,27 @@
 
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Core" Version="1.6.0" />
-    <PackageReference Include="docfx" Version="2.53.1" />
-    <PackageReference Include="docfx.console" Version="2.53.1">
+    <PackageReference Include="docfx" Version="2.56.2" />
+    <PackageReference Include="docfx.console" Version="2.56.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="MoonSharp" Version="2.0.0" />
-    <PackageReference Include="MSBuildGitHash" Version="2.0.1">
+    <PackageReference Include="MSBuildGitHash" Version="2.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Sentry" Version="2.1.5" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Enrichers.ExceptionData" Version="1.0.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.Map" Version="1.0.1" />
-    <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
+    <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.7.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/hybrasyl/Jobs.cs
+++ b/hybrasyl/Jobs.cs
@@ -83,6 +83,7 @@ namespace Hybrasyl
                 }
                 catch (Exception e)
                 {
+                    Game.ReportException(e);
                     GameLog.Error("Exception occured in job:", e);
                 }
             }
@@ -108,8 +109,9 @@ namespace Hybrasyl
                             mailbox.Cleanup();
                             mailbox.Unlock();
                         }
-                        catch (MessageStoreLocked)
+                        catch (MessageStoreLocked e)
                         {
+                            Game.ReportException(e);
                             GameLog.ErrorFormat("{0}: mailbox locked during cleanup...?", mailbox.Name);
                         }
                     }
@@ -121,8 +123,9 @@ namespace Hybrasyl
                             board.Cleanup();
                             board.Unlock();
                         }
-                        catch (MessageStoreLocked)
+                        catch (MessageStoreLocked e)
                         {
+                            Game.ReportException(e);
                             GameLog.ErrorFormat("{0}: board locked during cleanup...?", board.Name);
                         }
                     }
@@ -130,6 +133,7 @@ namespace Hybrasyl
                 }
                 catch (Exception e)
                 {
+                    Game.ReportException(e);
                     GameLog.Error("Exception occured in job:", e);
                 }
             }
@@ -155,6 +159,7 @@ namespace Hybrasyl
                 }
                 catch (Exception e)
                 {
+                    Game.ReportException(e);
                     GameLog.Error("Exception occured in job:", e);
                 }
             }
@@ -181,6 +186,7 @@ namespace Hybrasyl
                 }
                 catch (Exception e)
                 {
+                    Game.ReportException(e);
                     GameLog.Error("Exception occured in job:", e);
                 }
             }
@@ -206,6 +212,7 @@ namespace Hybrasyl
                 }
                 catch (Exception e)
                 {
+                    Game.ReportException(e);
                     GameLog.Error("Exception occured in job:", e);
                 }
             }
@@ -244,6 +251,7 @@ namespace Hybrasyl
                 }
                 catch (Exception e)
                 {
+                    Game.ReportException(e);
                     GameLog.ErrorFormat("Exception occurred in job:", e);
                 }
             }
@@ -317,6 +325,7 @@ namespace Hybrasyl
                 }
                 catch (Exception e)
                 {
+                    Game.ReportException(e);
                     GameLog.Error("Exception occured in job:", e);
                 }
             }

--- a/hybrasyl/Messaging/Admin.cs
+++ b/hybrasyl/Messaging/Admin.cs
@@ -570,7 +570,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "teleport";
         public new static string ArgumentText = "<string playername> | <string npcname> | <string mapname> <byte x> <byte y> | <uint mapnumber> <byte x> <byte y>";
         public new static string HelpText = "Teleport to the specified player, or the given map number and coordinates.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {

--- a/hybrasyl/Messaging/Debug.cs
+++ b/hybrasyl/Messaging/Debug.cs
@@ -28,7 +28,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "cleardialog";
         public new static string ArgumentText = "<string username>";
         public new static string HelpText = "Completely clear the dialog state for a given user.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {

--- a/hybrasyl/Messaging/Effects.cs
+++ b/hybrasyl/Messaging/Effects.cs
@@ -31,7 +31,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "motion";
         public new static string ArgumentText = "<byte motion> [<short speed>]";
         public new static string HelpText = "Displays the specified motion (player animation) with an optional speed.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -74,7 +74,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "effect";
         public new static string ArgumentText = "<byte effect>";
         public new static string HelpText = "Displays the specified effect (animation).";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -95,7 +95,8 @@ namespace Hybrasyl.Messaging
         public new static string Command = "sound";
         public new static string ArgumentText = "<byte sound>";
         public new static string HelpText = "Plays the specified sound effect.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
+
         public new static ChatCommandResult Run(User user, params string[] args)
         {
             if (byte.TryParse(args[0], out byte sound))
@@ -114,7 +115,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "music";
         public new static string ArgumentText = "<byte music>";
         public new static string HelpText = "Plays the specified background music.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -136,8 +137,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "item";
         public new static string ArgumentText = "<string itemName> [<uint quantity>]";
         public new static string HelpText = "Give yourself the specified item, with optional quantity.";
-        public new static bool Privileged = false;
-
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -161,8 +161,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "itemlist";
         public new static string ArgumentText = "<string searchTerm>";
         public new static string HelpText = "Searches for items with the specified search term.";
-        public new static bool Privileged = false;
-
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -196,7 +195,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "mapmsg";
         public new static string ArgumentText = "<string message>";
         public new static string HelpText = "Send a map message to everyone on the current map.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -214,7 +213,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "worldmsg";
         public new static string ArgumentText = "<string message>";
         public new static string HelpText = "Send a map message to everyone on the current map.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {

--- a/hybrasyl/Messaging/Info.cs
+++ b/hybrasyl/Messaging/Info.cs
@@ -33,7 +33,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "maplist";
         public new static string ArgumentText = "<string searchTerm>";
         public new static string HelpText = "Searches for maps with the specified search term.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {

--- a/hybrasyl/Messaging/Legend.cs
+++ b/hybrasyl/Messaging/Legend.cs
@@ -31,7 +31,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "legend";
         public new static string ArgumentText = "<string legendText> <byte icon> <byte color> | <int prefix> <int quantity> [<datetime date>]";
         public new static string HelpText = "Add a legend mark with the specified text, icon and color, and optionally with the given quantity and date.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -61,7 +61,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "title";
         public new static string ArgumentText = "<string title>";
         public new static string HelpText = "Change your displayed title.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -75,7 +75,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "legendclear";
         public new static string ArgumentText = "[<int marks>]";
         public new static string HelpText = "Clear your legend of the specified number of marks, starting at the end. If no argument given, CLEARS ALL MARKS. WARNING: Not reversible.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -98,7 +98,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "legendcolors";
         public new static string ArgumentText = "none";
         public new static string HelpText = "Adds a legend mark for each color code to your legend.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {

--- a/hybrasyl/Messaging/Stats.cs
+++ b/hybrasyl/Messaging/Stats.cs
@@ -31,7 +31,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "hp";
         public new static string ArgumentText = "<uint hp>";
         public new static string HelpText = "Set current HP to the specified uint value.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -50,7 +50,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "basehp";
         public new static string ArgumentText = "<uint hp>";
         public new static string HelpText = "Set base HP to the specified uint value.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -69,7 +69,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "mp";
         public new static string ArgumentText = "<uint mp>";
         public new static string HelpText = "Set current HP to the specified uint value.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -88,7 +88,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "basemp";
         public new static string ArgumentText = "<uint mp>";
         public new static string HelpText = "Set base HP to the specified uint value.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -107,7 +107,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "attr";
         public new static string ArgumentText = "<string attribute> <byte value>";
         public new static string HelpText = "Set a specified attribute (str/con etc) to the given byte value.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -147,7 +147,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "gold";
         public new static string ArgumentText = "<uint gold>";
         public new static string HelpText = "Give yourself the specified amount of gold.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -165,7 +165,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "damage";
         public new static string ArgumentText = "<double damage>";
         public new static string HelpText = "Damage yourself for the specified amount. Careful...";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
         
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -182,7 +182,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "exp";
         public new static string ArgumentText = "<uint experience>";
         public new static string HelpText = "Award yourself a given amount of experience.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -200,7 +200,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "expreset";
         public new static string ArgumentText = "<none>";
         public new static string HelpText = "Reset level, experience, and level points (level 1, 0 XP, 0 points).";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -218,7 +218,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "nation";
         public new static string ArgumentText = "<string nation>";
         public new static string HelpText = "Make yourself a citizen of the specified nation.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -237,7 +237,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "class";
         public new static string ArgumentText = "<string class>";
         public new static string HelpText = "Change your class to the one specified.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -257,7 +257,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "level";
         public new static string ArgumentText = "<byte level>";
         public new static string HelpText = "Change your level to the one specified.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -277,7 +277,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "skill";
         public new static string ArgumentText = "<string skillName>";
         public new static string HelpText = "Add the specified skill to your skillbook.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -296,7 +296,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "spell";
         public new static string ArgumentText = "<string spellName>";
         public new static string HelpText = "Add the specified spell to your spellbook.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -315,7 +315,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "master";
         public new static string ArgumentText = "none";
         public new static string HelpText = "Toggle mastership.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {

--- a/hybrasyl/Messaging/Statuses.cs
+++ b/hybrasyl/Messaging/Statuses.cs
@@ -29,7 +29,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "status";
         public new static string ArgumentText = "<string statusName>";
         public new static string HelpText = "Apply a given status to yourself.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -47,7 +47,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "clearstatus";
         public new static string ArgumentText = "none";
         public new static string HelpText = "Clear all statuses and conditions.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {
@@ -64,7 +64,7 @@ namespace Hybrasyl.Messaging
         public new static string Command = "clearflags";
         public new static string ArgumentText = "none";
         public new static string HelpText = "Clear all player flags.";
-        public new static bool Privileged = false;
+        public new static bool Privileged = true;
 
         public new static ChatCommandResult Run(User user, params string[] args)
         {

--- a/hybrasyl/Monolith.cs
+++ b/hybrasyl/Monolith.cs
@@ -506,6 +506,7 @@ namespace Hybrasyl
                 }
                 catch (Exception e)
                 {
+                    Game.ReportException(e);
                     GameLog.SpawnError(e, "Spawngroup {Filename}: disabled map {Name} due to error", spawnGroup.Filename, map.Name);
                     map.Disabled = true;
                     continue;

--- a/hybrasyl/NumberCruncher.cs
+++ b/hybrasyl/NumberCruncher.cs
@@ -63,6 +63,7 @@ namespace Hybrasyl
             }
             catch (Exception e)
             {
+                Game.ReportException(e);
                 GameLog.Error($"NumberCruncher formula error: castable {castable.Name}, target {target.Name}, source {source?.Name ?? "no source"}: {formula}, error: {e}");
                 return 0;
             }

--- a/hybrasyl/Objects/Merchant.cs
+++ b/hybrasyl/Objects/Merchant.cs
@@ -61,10 +61,13 @@ namespace Hybrasyl.Objects
 
         public override void OnHear(VisibleObject speaker, string text, bool shout = false)
         {
+            if (speaker == this)
+                return;
+
             if (!Ready)
                 OnSpawn();
 
-            if (Script != null && Script.HasFunction("OnHear"))
+            if (Script != null)
             {
                 Script.SetGlobalValue("text", text);
                 Script.SetGlobalValue("shout", shout);

--- a/hybrasyl/Objects/Monster.cs
+++ b/hybrasyl/Objects/Monster.cs
@@ -132,8 +132,7 @@ namespace Hybrasyl.Objects
 
             // FIXME: in the glorious future, run asynchronously with locking
             InitScript();
-
-            if (Script.HasFunction("OnHear"))
+            if (Script != null && !ScriptDisabled)
             {
                 Script.SetGlobalValue("text", text);
                 Script.SetGlobalValue("shout", shout);
@@ -149,7 +148,7 @@ namespace Hybrasyl.Objects
         {
             // FIXME: in the glorious future, run asynchronously with locking
             InitScript();
-            if (Script != null)
+            if (Script != null && !ScriptDisabled)
             {
                 Script.SetGlobalValue("damage", damage);
                 Script.ExecuteFunction("OnDamage", this, attacker);
@@ -160,7 +159,7 @@ namespace Hybrasyl.Objects
         {
             // FIXME: in the glorious future, run asynchronously with locking
             InitScript();
-            if (Script != null)
+            if (Script != null && !ScriptDisabled)
             {
                 Script.SetGlobalValue("heal", heal);
                 Script.ExecuteFunction("OnHeal", this, healer);

--- a/hybrasyl/Objects/Monster.cs
+++ b/hybrasyl/Objects/Monster.cs
@@ -52,7 +52,7 @@ namespace Hybrasyl.Objects
         public bool MovementDisabled => _spawn.Flags.HasFlag(Xml.SpawnFlags.MovementDisabled);
         public bool AiDisabled => _spawn.Flags.HasFlag(Xml.SpawnFlags.AiDisabled);
 
-        public bool ScriptDisabled { get; set; }
+        public bool ScriptExists { get; set; }
 
         public override void OnDeath()
         {
@@ -112,17 +112,17 @@ namespace Hybrasyl.Objects
         // OnSpawn) when not needed 99% of the time.
         private void InitScript()
         {
-            if (Script != null || ScriptDisabled == true)
+            if (Script != null || !ScriptExists)               
                 return;
 
             if (World.ScriptProcessor.TryGetScript(Name, out Script damageScript))
             {
                 Script = damageScript;
                 Script.AssociateScriptWithObject(this);
-                ScriptDisabled = false;
+                ScriptExists = true;
             }
             else
-                ScriptDisabled = true;                
+                ScriptExists = false;                
         }
 
         public override void OnHear(VisibleObject speaker, string text, bool shout = false)
@@ -132,7 +132,7 @@ namespace Hybrasyl.Objects
 
             // FIXME: in the glorious future, run asynchronously with locking
             InitScript();
-            if (Script != null && !ScriptDisabled)
+            if (Script != null)
             {
                 Script.SetGlobalValue("text", text);
                 Script.SetGlobalValue("shout", shout);
@@ -148,7 +148,8 @@ namespace Hybrasyl.Objects
         {
             // FIXME: in the glorious future, run asynchronously with locking
             InitScript();
-            if (Script != null && !ScriptDisabled)
+
+            if (Script != null)
             {
                 Script.SetGlobalValue("damage", damage);
                 Script.ExecuteFunction("OnDamage", this, attacker);
@@ -159,7 +160,7 @@ namespace Hybrasyl.Objects
         {
             // FIXME: in the glorious future, run asynchronously with locking
             InitScript();
-            if (Script != null && !ScriptDisabled)
+            if (Script != null)
             {
                 Script.SetGlobalValue("heal", heal);
                 Script.ExecuteFunction("OnHeal", this, healer);

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -263,12 +263,7 @@ namespace Hybrasyl.Objects
         {
             get
             {
-                if (Game.Config.Access?.Privileged != null)
-                {
-                    return IsExempt || Flags.ContainsKey("gamemaster") ||
-                        Game.Config.Access.Privileged.IndexOf(Name, 0, StringComparison.CurrentCultureIgnoreCase) != -1;
-                }
-                return IsExempt || Flags.ContainsKey("gamemaster");
+                return IsExempt || Flags.ContainsKey("gamemaster") || (Game.Config.Access?.IsPrivileged(this.Name) ?? false);
             }
         }
 
@@ -965,6 +960,7 @@ namespace Hybrasyl.Objects
             }
             catch (Exception e)
             {
+                Game.ReportException(e);
                 GameLog.ErrorFormat("Exception trying to set {0} to {1}", info.Name, value.ToString());
                 GameLog.ErrorFormat(e.ToString());
                 throw;
@@ -4483,8 +4479,9 @@ namespace Hybrasyl.Objects
                 {
                     Client.Socket.Disconnect(true);
                 }
-                catch (ObjectDisposedException)
+                catch (ObjectDisposedException e)
                 {
+                    Game.ReportException(e);
                     Client.ClientState = null;
                 }
         }

--- a/hybrasyl/Packet.cs
+++ b/hybrasyl/Packet.cs
@@ -286,7 +286,6 @@ namespace Hybrasyl
             }
             catch (Exception)
             {
-
                 Array.Resize(ref buffer, Data.Length + shouldEncrypt + 2);
             }
             finally

--- a/hybrasyl/Scripting/HybrasylUser.cs
+++ b/hybrasyl/Scripting/HybrasylUser.cs
@@ -412,6 +412,7 @@ namespace Hybrasyl.Scripting
             }
             catch (Exception e)
             {
+                Game.ReportException(e);
                 GameLog.ScriptingError("SetSessionCookie: {user}: value (second argument) could not be converted to string? {error}", User.Name, e);
             }
         }
@@ -438,6 +439,7 @@ namespace Hybrasyl.Scripting
             }
             catch (Exception e)
             {
+                Game.ReportException(e);
                 GameLog.ScriptingError("SetCookie: {user} - value (second argument) could not be converted to string? {exception}", User.Name, e.ToString());
             }
 

--- a/hybrasyl/Scripting/HybrasylUtility.cs
+++ b/hybrasyl/Scripting/HybrasylUtility.cs
@@ -74,6 +74,7 @@ namespace Hybrasyl.Scripting
             }
             catch (Exception e)
             {
+                Game.ReportException(e);
                 GameLog.ScriptingError("HoursBetweenUnixTimes: Exception occurred doing time conversion, returning 0 - {exception}", e);
                 return 0;
             }

--- a/hybrasyl/Scripting/Script.cs
+++ b/hybrasyl/Scripting/Script.cs
@@ -263,6 +263,7 @@ namespace Hybrasyl.Scripting
             }
             catch (Exception ex)
             {
+                Game.ReportException(ex);
                 var error_msg = HumanizeException(ex);
                 GameLog.ScriptingError("Run: Error executing script {FileName} (associate {assoc}): {Message}",
                                   FileName, Associate?.Name ?? "none", error_msg);
@@ -329,6 +330,7 @@ namespace Hybrasyl.Scripting
             }
             catch (Exception ex) 
             {
+                Game.ReportException(ex);
                 var error_msg = HumanizeException(ex);
                 GameLog.ScriptingError("Execute: Error executing expression {expr} in {FileName} (associate {associate}, invoker {invoker}, source {source}): {Message}",
                     expr, FileName, Associate?.Name ?? "none", invoker?.Name ?? "none", source?.Name ?? "none", error_msg);
@@ -354,6 +356,7 @@ namespace Hybrasyl.Scripting
             }
             catch (Exception ex)
             {
+                Game.ReportException(ex);
                 var error_msg = HumanizeException(ex);
                 GameLog.ScriptingError("Execute: Error executing expression {expr} in {FileName} (associate {associate}, invoker {invoker}): {Message}",
                     expr, FileName, Associate?.Name ?? "none", invoker?.Name ?? "none", error_msg);
@@ -388,6 +391,7 @@ namespace Hybrasyl.Scripting
             }
             catch (Exception ex) 
             {
+                Game.ReportException(ex);
                 var error_msg = HumanizeException(ex);
                 GameLog.ScriptingError("ExecuteFunction: Error executing function {fn} in {FileName} (associate {associate}, invoker {invoker}, item {item}): {Message}",
                     functionName, FileName, Associate?.Name ?? "none", invoker?.Name ?? "none", scriptItem?.Name ?? "none", error_msg);
@@ -420,6 +424,7 @@ namespace Hybrasyl.Scripting
             }
             catch (Exception ex)
             {
+                Game.ReportException(ex);
                 var error_msg = HumanizeException(ex);
                 GameLog.ScriptingError("ExecuteFunction: Error executing function {fn} in {FileName} (associate {associate}, invoker {invoker}): {Message}",
                     functionName, FileName, Associate?.Name ?? "none", invoker?.Name ?? "none", error_msg);
@@ -465,6 +470,7 @@ namespace Hybrasyl.Scripting
             }
             catch (Exception ex)
             {
+                Game.ReportException(ex);
                 var error_msg = HumanizeException(ex);
                 GameLog.ScriptingError("ExecuteFunction: Error executing function {fn} in {FileName} (associate {associate}): {Message}",
                     functionName, FileName, Associate?.Name ?? "none", error_msg);

--- a/hybrasyl/Server.cs
+++ b/hybrasyl/Server.cs
@@ -142,6 +142,7 @@ namespace Hybrasyl
             }
             catch (ObjectDisposedException e)
             {
+                Game.ReportException(e);
                 GameLog.Error($"Disposed socket {e.Message}");
                 return;
             }
@@ -175,8 +176,9 @@ namespace Hybrasyl
                 GameLog.DebugFormat("AcceptConnection returning");
                 clientSocket.BeginAccept(new AsyncCallback(AcceptConnection), clientSocket);
             }
-            catch (SocketException)
+            catch (SocketException e)
             {
+                Game.ReportException(e);
                 handler.Close();
             }
         }
@@ -222,6 +224,7 @@ namespace Hybrasyl
             catch (Exception e)
             {
                 GameLog.Fatal($"EndReceive Error:  {e.Message}");
+                Game.ReportException(e);
                 client.Disconnect();
             }
 
@@ -235,6 +238,7 @@ namespace Hybrasyl
             }
             catch (Exception e)
             {
+                Game.ReportException(e);
                 GameLog.Error($"ReadCallback error: {e.Message}");
             }
             ContinueReceiving(state, client);
@@ -251,12 +255,14 @@ namespace Hybrasyl
             }
             catch (ObjectDisposedException e)
             {
+                Game.ReportException(e);
                 GameLog.Fatal(e.Message);
                 //client.Disconnect();
                 state.WorkSocket.Close();
             }
             catch (SocketException e)
             {
+                Game.ReportException(e);
                 GameLog.Fatal(e.Message);
                 client.Disconnect();
             }

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -651,9 +651,12 @@ namespace Hybrasyl
                 // in <Privileged>
                 var board = GetBoard("Hybrasyl");
                 board.DisplayName = "Hybrasyl Global Board";
-                foreach (var moderator in Game.Config.Access.Privileged)
-                    board.SetAccessLevel(Convert.ToString(moderator), BoardAccessLevel.Moderate);
-                board.Save();
+                if (Game.Config.Access != null)
+                {
+                    foreach (var moderator in Game.Config.Access.PrivilegedUsers)
+                        board.SetAccessLevel(moderator, BoardAccessLevel.Moderate);
+                    board.Save();
+                }
             }
             return true;
         }
@@ -3070,8 +3073,9 @@ namespace Hybrasyl
                                     response.WriteString8("{0}'s mailbox is full. Your message was discarded. Sorry!");
                                 }
                             }
-                            catch (MessageStoreLocked)
+                            catch (MessageStoreLocked e)
                             {
+                                Game.ReportException(e);
                                 response.WriteBoolean(true);
                                 response.WriteString8("{0} cannot receive mail at this time. Sorry!");
                             }
@@ -4280,6 +4284,7 @@ namespace Hybrasyl
                 }
                 catch (InvalidOperationException e)
                 {
+                    Game.ReportException(e);
                     if (!MessageQueue.IsCompleted)
                         GameLog.Error($"QUEUE CONSUMER: EXCEPTION RAISED: {e}", e);
                     continue;
@@ -4361,6 +4366,7 @@ namespace Hybrasyl
                     }
                     catch (Exception e)
                     {
+                        Game.ReportException(e);
                         GameLog.Error(e, "{Opcode}: Unhandled exception encountered in packet handler!", clientMessage.Packet.Opcode);
                     }
                 }
@@ -4383,7 +4389,8 @@ namespace Hybrasyl
                 }
                 catch (InvalidOperationException e)
                 {
-                    GameLog.Error(e, "QUEUE CONSUMER: EXCEPTION RAISED: {exception}");
+                    Game.ReportException(e);
+                    GameLog.Error("QUEUE CONSUMER: EXCEPTION RAISED: {exception}", e);
                     continue;
                 }
 
@@ -4396,7 +4403,8 @@ namespace Hybrasyl
                     }
                     catch (Exception e)
                     {
-                        GameLog.Error(e, "Exception encountered in control message handler: {exception}");
+                        Game.ReportException(e);
+                        GameLog.Error("Exception encountered in control message handler: {exception}", e);
                     }
                 }
             }


### PR DESCRIPTION
## Description
This PR adds Sentry for error reporting in most places (and all unhandled exceptions). It also simplifies access checks for privileged uses and adds support for a wildcard (e.g. `*`) to make local testing easier.

Also corrects a few bugs in the new `OnHear` handler for mundanes.

Lastly, most slash commands are now defaulted to requiring privilege as we get closer to alpha.

## Impacted Areas in Hybrasyl
Privileged user checks
All exception handling
