### PR TITLE
Clean up storage of logged in users / fix worlddatastore bugs

### DIFF
--- a/hybrasyl/Client.cs
+++ b/hybrasyl/Client.cs
@@ -655,13 +655,19 @@ namespace Hybrasyl
             if (Connected)
                 ClientState.SendBufferAdd(packet);
             else
-                throw new ObjectDisposedException("Client is no longer connected");
+            {
+                // Trigger cleanup
+                Disconnect();
+                return;
+            }
         }
 
         public void Enqueue(ClientPacket packet)
         {
             GameLog.DebugFormat("Enqueueing ClientPacket {0}", packet.Opcode);
             ClientState.ReceiveBufferAdd(packet);
+            if (!Connected)
+                Disconnect();
             if (!packet.ShouldEncrypt || (packet.ShouldEncrypt && EncryptionKey != null))
                 FlushReceiveBuffer();
         }

--- a/hybrasyl/CreatureStatus.cs
+++ b/hybrasyl/CreatureStatus.cs
@@ -348,7 +348,8 @@ namespace Hybrasyl
 
         private void ProcessNumericEffects(SimpleStatusEffect effect)
         {
-            if (effect.Damage != null)
+            if (effect == null) return;
+            if (effect.Damage != null && effect.Damage.Amount != 0)
                 Target.Damage(effect.Damage.Amount, effect.Damage.Element, effect.Damage.Type, effect.Damage.Flags, Source);
             if (effect.Heal != 0)
                 Target.Heal(effect.Heal, Source);

--- a/hybrasyl/Jobs.cs
+++ b/hybrasyl/Jobs.cs
@@ -237,7 +237,7 @@ namespace Hybrasyl
                         var client = connection.Value;
                         var connectionId = connection.Key;
                         User user;
-                        if (World.ActiveUsers.TryGetValue(connectionId, out user))
+                        if (Game.World.WorldData.TryGetValueByIndex(connectionId, out user))
                         {
                             if (client.IsHeartbeatExpired())
                             {
@@ -280,7 +280,7 @@ namespace Hybrasyl
                 foreach (var connectionId in GlobalConnectionManifest.WorldClients.Keys)
                 {
                     User user;
-                    if (World.ActiveUsers.TryGetValue(connectionId, out user))
+                    if (Game.World.WorldData.TryGetValueByIndex(connectionId, out user))
                     {
                         if (user.Statuses.Count > 0 && user.Condition.Alive)
                             World.ControlMessageQueue.Add(new HybrasylControlMessage(ControlOpcodes.StatusTick, user.Id));
@@ -314,7 +314,7 @@ namespace Hybrasyl
                         if (client.IsIdle())
                         {
                             User user;
-                            if (World.ActiveUsers.TryGetValue(connectionId, out user))
+                            if (Game.World.WorldData.TryGetValueByIndex(connectionId, out user))
                             {
                                 user.Motion(16, 120); // send snore effect
                             }

--- a/hybrasyl/Login.cs
+++ b/hybrasyl/Login.cs
@@ -107,7 +107,7 @@ namespace Hybrasyl
             {
                 GameLog.DebugFormat("cid {0}: password verified for {1}", client.ConnectionId, name);
 
-                if (Game.World.ActiveUsersByName.ContainsKey(name))
+                if (Game.World.WorldData.ContainsKey<User>(name))
                 {
                     GameLog.InfoFormat("cid {0}: {1} logging on again, disconnecting previous connection",
                         client.ConnectionId, name);

--- a/hybrasyl/Messaging/Effects.cs
+++ b/hybrasyl/Messaging/Effects.cs
@@ -218,9 +218,9 @@ namespace Hybrasyl.Messaging
         public new static ChatCommandResult Run(User user, params string[] args)
         {
             user.Map.Message = args[0];
-            foreach (var connectedUser in World.ActiveUsers)
+            foreach (var connectedUser in Game.World.WorldData.Values<User>())
             {
-                connectedUser.Value.SendWorldMessage(user.Name, args[0]);
+                connectedUser.SendWorldMessage(user.Name, args[0]);
             }
             return Success("World message sent.");
         }

--- a/hybrasyl/Objects/Creature.cs
+++ b/hybrasyl/Objects/Creature.cs
@@ -861,7 +861,7 @@ namespace Hybrasyl.Objects
         {
             if (attacker is User && this is Monster)
             {
-                if (FirstHitter == null || !Game.World.ActiveUsersByName.ContainsKey(FirstHitter.Name) || ((DateTime.Now - LastHitTime).TotalSeconds > Constants.MONSTER_TAGGING_TIMEOUT)) FirstHitter = attacker;
+                if (FirstHitter == null || !World.UserConnected(FirstHitter.Name) || ((DateTime.Now - LastHitTime).TotalSeconds > Constants.MONSTER_TAGGING_TIMEOUT)) FirstHitter = attacker;
                 if (attacker != FirstHitter && !((FirstHitter as User).Group?.Members.Contains(attacker) ?? false)) return;
             }
 

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -82,6 +82,8 @@ namespace Hybrasyl.Objects
         public string AccountUuid { get; set; }
 
         private Client Client;
+        public bool Connected => Client.Connected;
+        public long ConnectionId => Client.ConnectionId;
 
         [JsonProperty]
         public Xml.Gender Gender { get; set; }
@@ -4705,7 +4707,7 @@ namespace Hybrasyl.Objects
             else
                 try
                 {
-                    Client.Socket.Disconnect(true);
+                    Client.Disconnect();
                 }
                 catch (ObjectDisposedException e)
                 {

--- a/hybrasyl/Objects/VisibleObject.cs
+++ b/hybrasyl/Objects/VisibleObject.cs
@@ -174,7 +174,7 @@ namespace Hybrasyl.Objects
         public virtual void Teleport(string name, byte x, byte y)
         {
             Map targetMap;
-            if (!World.WorldData.TryGetValueByIndex(name, out targetMap)) return;
+            if (string.IsNullOrEmpty(name) || !World.WorldData.TryGetValueByIndex(name, out targetMap)) return;
             Map?.Remove(this);
             GameLog.DebugFormat("Teleporting {0} to {1}.", Name, targetMap.Name);
             targetMap.Insert(this, x, y);

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -1,4 +1,5 @@
 ﻿/*
+ *
  * This file is part of Project Hybrasyl.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -114,8 +115,6 @@ namespace Hybrasyl
 
         public static BlockingCollection<HybrasylMessage> MessageQueue;
         public static BlockingCollection<HybrasylMessage> ControlMessageQueue;
-        public static ConcurrentDictionary<long, User> ActiveUsers { get; private set; }
-        public ConcurrentDictionary<string, long> ActiveUsersByName { get; set; }
 
         public ConcurrentDictionary<Tuple<UInt32, UInt32>, AsyncDialogRequest> ActiveAsyncDialogs { get; set; }
 
@@ -209,9 +208,7 @@ namespace Hybrasyl
             ScriptProcessor = new ScriptProcessor(this);
             MessageQueue = new BlockingCollection<HybrasylMessage>(new ConcurrentQueue<HybrasylMessage>());
             ControlMessageQueue = new BlockingCollection<HybrasylMessage>(new ConcurrentQueue<HybrasylMessage>());
-            ActiveUsers = new ConcurrentDictionary<long, User>();
-            ActiveUsersByName = new ConcurrentDictionary<string, long>();
-
+       
             ActiveAsyncDialogs = new ConcurrentDictionary<Tuple<UInt32, UInt32>, AsyncDialogRequest>();
 
             WorldData = new WorldDataStore();
@@ -1423,13 +1420,28 @@ namespace Hybrasyl
 
         #endregion Set Handlers
 
-        public void DeleteUser(string username) => WorldData.Remove<User>(username);
+        public void DeleteUser(string username)
+        {
+            if (TryGetActiveUser(username, out User user))
+                WorldData.RemoveIndex<User>(user.ConnectionId);
+            WorldData.Remove<User>(username);
+        }
 
-        public void AddUser(User userobj) => WorldData.Set(userobj.Name, userobj);
+        public void AddUser(User userobj, long connectionId) => WorldData.SetWithIndex(userobj.Name, userobj, connectionId);
 
         public bool TryGetActiveUser(string name, out User user) => WorldData.TryGetValue(name, out user);
 
-        public bool UserConnected(string name) => ActiveUsersByName.ContainsKey(name);
+        public bool TryGetActiveUserById(long connectionId, out User user) => WorldData.TryGetValueByIndex(connectionId, out user);
+
+        public IEnumerable<User> ActiveUsers => WorldData.Values<User>();
+
+        public bool UserConnected(string name)
+        {
+            if (WorldData.TryGetValue(name, out User user))
+                return user.Connected;
+            else
+                return false;
+        }
 
         public bool TryAsyncDialog(VisibleObject invoker, User invokee, DialogSequence startSequence)
         {
@@ -1459,12 +1471,11 @@ namespace Hybrasyl
         }
         public override void Shutdown()
         {
-            GameLog.WarningFormat("Shutdown initiated, disconnecting {0} active users", ActiveUsers.Count);
+            GameLog.WarningFormat("Shutdown initiated, disconnecting {0} active users", ActiveUsers.Count());
 
             Active = false;
-            foreach (var connection in ActiveUsers)
+            foreach (var user in ActiveUsers)
             {
-                var user = connection.Value;
                 user.Logoff(true);
             }
             Listener?.Close();
@@ -1477,13 +1488,12 @@ namespace Hybrasyl
         {
             // clean up after a broken connection
             var connectionId = (long)message.Arguments[0];
-            User user;
-            if (ActiveUsers.TryRemove(connectionId, out user))
+
+            if (TryGetActiveUserById(connectionId, out User user))
             {
                 GameLog.InfoFormat("cid {0}: closed, player {1} removed", connectionId, user.Name);
                 if (user.ActiveExchange != null)
                     user.ActiveExchange.CancelExchange(user);
-                ((IDictionary)ActiveUsersByName).Remove(user.Name);
                 user.UpdateLogoffTime();
                 user.Map?.Remove(user);
                 user.Group?.Remove(user);
@@ -1501,7 +1511,7 @@ namespace Hybrasyl
             // Regen = regen * 0.0015 (so 100 regen = 15%)
             User user;
             var connectionId = (long)message.Arguments[0];
-            if (ActiveUsers.TryGetValue(connectionId, out user))
+            if (TryGetActiveUserById(connectionId, out user))
             {
                 uint hpRegen = 0;
                 uint mpRegen = 0;
@@ -1533,7 +1543,7 @@ namespace Hybrasyl
             // save a user
             User user;
             var connectionId = (long)message.Arguments[0];
-            if (ActiveUsers.TryGetValue(connectionId, out user))
+            if (TryGetActiveUserById(connectionId, out user))
             {
                 GameLog.DebugFormat("Saving user {0}", user.Name);
                 user.Save();
@@ -1551,9 +1561,8 @@ namespace Hybrasyl
             var userName = (string)message.Arguments[0];
             GameLog.WarningFormat("Server shutdown request initiated by {0}", userName);
             // Chaos is Rising Up, yo.
-            foreach (var connection in ActiveUsers)
+            foreach (var user in ActiveUsers)
             {
-                var user = connection.Value;
                 user.SendMessage("Chaos is rising up. Please re-enter in a few minutes.",
                     MessageTypes.SYSTEM_WITH_OVERHEAD);
             }
@@ -1571,7 +1580,7 @@ namespace Hybrasyl
             var userName = (string)message.Arguments[0];
             GameLog.WarningFormat("{0}: forcing logoff", userName);
             User user;
-            if (WorldData.TryGetValue(userName, out user))
+            if (TryGetActiveUser(userName, out user))
             {
                 user.Logoff();
             }
@@ -1583,7 +1592,7 @@ namespace Hybrasyl
             var userName = (string)message.Arguments[0];
             GameLog.DebugFormat("mail: attempting to notify {0} of new mail", userName);
             User user;
-            if (WorldData.TryGetValue(userName, out user))
+            if (TryGetActiveUser(userName, out user))
             {
                 user.UpdateAttributes(StatUpdateFlags.Secondary);
                 GameLog.DebugFormat("mail: notification to {0} sent", userName);
@@ -1610,7 +1619,7 @@ namespace Hybrasyl
         private void ControlMessage_TriggerRefresh(HybrasylControlMessage message)
         {
             var connectionId = (long)message.Arguments[0];
-            if (ActiveUsers.TryGetValue(connectionId, out User user))
+            if (TryGetActiveUserById(connectionId, out User user))
                 user.Refresh();
         }
 
@@ -1913,9 +1922,6 @@ namespace Hybrasyl
             }
             else
             {
-                long connectionId;
-
-                //user.Save();
                 user.UpdateLogoffTime();
                 user.Map.Remove(user);
                 if (user.Grouped)
@@ -1923,8 +1929,9 @@ namespace Hybrasyl
                     user.Group.Remove(user);
                 }
                 Remove(user);
-                DeleteUser(user.Name);
                 user.SendRedirectAndLogoff(this, Game.Login, user.Name);
+                user.Save();
+                DeleteUser(user.Name);
 
                 // Remove any active async dialog sessions
                 foreach (var dialog in ActiveAsyncDialogs.Keys.Where(key => key.Item1 == user.Id || key.Item2 == user.Id))
@@ -1932,12 +1939,8 @@ namespace Hybrasyl
                     if (ActiveAsyncDialogs.TryRemove(dialog, out AsyncDialogRequest request))
                         request.End();
                 }
-
-                if (ActiveUsersByName.TryRemove(user.Name, out connectionId))
-                {
-                    ((IDictionary)ActiveUsers).Remove(connectionId);
-                }
-                GameLog.InfoFormat("cid {0}: {1} leaving world", connectionId, user.Name);
+                
+                GameLog.InfoFormat("{1} leaving world", user.Name);
             }
         }
 
@@ -1985,6 +1988,9 @@ namespace Hybrasyl
             loginUser.Condition.Casting = false;
 
             Insert(loginUser);
+            GameLog.DebugFormat("Adding {0} to hash", loginUser.Name);
+            AddUser(loginUser, connectionId);
+
             GameLog.DebugFormat("Elapsed time since login: {0}", loginUser.SinceLastLogin);
 
             if (!loginUser.Condition.Alive)
@@ -2032,10 +2038,6 @@ namespace Hybrasyl
                 loginUser.Teleport((ushort)500, (byte)50, (byte)50);
             }
 
-            GameLog.DebugFormat("Adding {0} to hash", loginUser.Name);
-            AddUser(loginUser);
-            ActiveUsers[connectionId] = loginUser;
-            ActiveUsersByName[loginUser.Name] = connectionId;
             GameLog.InfoFormat("cid {0}: {1} entering world", connectionId, loginUser.Name);
             GameLog.InfoFormat($"{loginUser.SinceLastLoginstring}");
             // If the user's never logged off before (new character), don't display this message.
@@ -2068,7 +2070,7 @@ namespace Hybrasyl
         {
             var me = (User)obj;
 
-            var list = from user in ActiveUsers.Values
+            var list = from user in ActiveUsers
                        orderby user.IsMaster descending, user.Stats.Level descending, user.Stats.BaseHp + user.Stats.BaseMp * 2 descending, user.Name ascending
                        select user;
 
@@ -4200,17 +4202,10 @@ namespace Hybrasyl
             user.ShowRepairAllItemsAccept(merchant);
         }
 
-
-
         #endregion Merchant Menu ItemObject Handlers
 
         public void Insert(WorldObject obj)
         {
-            if (obj is User)
-            {
-                AddUser((User)obj);
-            }
-
             obj.Id = worldObjectID;
             obj.World = this;
             obj.SendId();
@@ -4234,10 +4229,6 @@ namespace Hybrasyl
 
         public void Remove(WorldObject obj)
         {
-            if (obj is User)
-            {
-                DeleteUser(obj.Name);
-            }
             lock (_lock)
             {
                 Objects.Remove(obj.Id);
@@ -4302,7 +4293,7 @@ namespace Hybrasyl
                     var handler = PacketHandlers[clientMessage.Packet.Opcode];
                     try
                     {
-                        if (ActiveUsers.TryGetValue(clientMessage.ConnectionId, out user))
+                        if (TryGetActiveUserById(clientMessage.ConnectionId, out user))
                         {
                             // Check if the action is prohibited due to statuses or flags
                             MethodBase method = handler.GetMethodInfo();

--- a/hybrasyl/WorldDataStore.cs
+++ b/hybrasyl/WorldDataStore.cs
@@ -179,7 +179,6 @@ namespace Hybrasyl
         public bool SetWithIndex<T>(dynamic key, T value, dynamic index) => GetSubStore<T>().TryAdd(Sanitize(key), value) && 
             GetSubIndex<T>().TryAdd(Sanitize(index), value);
    
-
         /// <summary>
         /// Returns all the objects contained in the datastore of the specified type's substore.
         /// </summary>
@@ -224,8 +223,12 @@ namespace Hybrasyl
         /// <returns></returns>
         public bool Remove<T>(dynamic key)
         {
-            dynamic ignored;
-            return GetSubStore<T>().TryRemove(key.ToString().Normalize(), out ignored);
+            return GetSubStore<T>().TryRemove(Sanitize(key), out dynamic _);
+        }
+
+        public bool RemoveIndex<T>(dynamic index)
+        {
+            return GetSubIndex<T>().TryRemove(Sanitize(index), out dynamic _);
         }
 
         // Convenience finder functions below for various non-generic types.


### PR DESCRIPTION
This PR cleans up our storage and usage of logged in users. There were a couple of bugs / unintended consequences:

1) `WorldData.Remove` was not sanitizing the key, which means was not lowercased; so if you were logged in as Science, remove was attempting to remove the key "science". This means the user object would persist after logout in a particularly interesting state (client disconnected, but still in world). I believe this wasn't helping re: the "ghost" issue.

2) `WorldData<User>` was being used to store user objects but partially because of above, would eventually diverge from the contents of the `ActiveUsers` concurrent dictionary. `ActiveUsers` is basically tech debt at this point and has been removed. Any usage of it has been cleaned up. `ActiveUsers` property can still be accessed via World, and has just been changed to be an `IEnumerable` on the logged-in users (`<User>.Values()`)in the world data store.

3) There has never been a need to remove something by index or clean up the index. I added `RemoveIndex` and use it to clean up by connection id when needed.

4) Server logs show that Enqueue is throwing unhandled exceptions when clients disconnect or other weirdness occurs. If Enqueue fails due to client being disconnected, there is no hope of sending more packets; we should complete the  disconnect tasks (removing user & sending cleanup control message) and force the issue. 

5) Teleport / Summon were using the "bad" value for users. Now everything _only_ uses WorldData to get user objects.

6) Cleanup wasn't always occurring. Item 4 above forces the issue.

This conclusively fixes:

1) teleport / summon will do extremely weird things to logged off users
2) kick doesn't work (fixed)

This may fix:

1) general black screen weirdness seen in various places

At any rate, it's a first step towards more improvements. This will need extensive testing with our guinea pigs^H^H^H^H^H^H^H^H^H^H^H^Halpha users.


