### PR TITLE
Fix packet processing issue

### DIFF
--- a/hybrasyl/Client.cs
+++ b/hybrasyl/Client.cs
@@ -146,8 +146,9 @@ namespace Hybrasyl
                 {
                     var packetLength = (_buffer[1] << 8) + _buffer[2] + 3;
                     // Complete packet, pop it off and return it
-                    if (_buffer.Length >= packetLength)
+                    if (BytesReceived >= packetLength)
                     {
+                        BytesReceived -= packetLength;
                         packet = new ClientPacket(ReceiveBufferPop(packetLength).ToArray());
                         if (packet.Opcode == 0x3B)
                             GameLog.PacketInfo("0x3B: [TryGetPacket] [ENC] ({hash}) {data}", packet.Hash(), packet.ToString());
@@ -157,6 +158,8 @@ namespace Hybrasyl
                 return false;
             }
         }
+
+        public int BytesReceived = 0;
 
         public void ReceiveBufferAdd(ClientPacket packet) => _receiveBuffer.Enqueue(packet);
 

--- a/hybrasyl/Client.cs
+++ b/hybrasyl/Client.cs
@@ -149,6 +149,8 @@ namespace Hybrasyl
                     if (_buffer.Length >= packetLength)
                     {
                         packet = new ClientPacket(ReceiveBufferPop(packetLength).ToArray());
+                        if (packet.Opcode == 0x3B)
+                            GameLog.PacketInfo("0x3B: [TryGetPacket] [ENC] ({hash}) {data}", packet.Hash(), packet.ToString());
                         return true;
                     }
                 }
@@ -534,11 +536,16 @@ namespace Hybrasyl
                     {
                         //GameLog.Info("Debug - packet before decryption");
                         //packet.DumpPacket();
+                        if (packet.Opcode == 0x3B)
+                            GameLog.PacketInfo("0x3B: [ClientTake] [ENC] ({hash}) {data}", packet.Hash(), packet.ToString());
 
                         if (packet.ShouldEncrypt)
                         {
                             packet.Decrypt(this);
                         }
+
+                        if (packet.Opcode == 0x3B)
+                            GameLog.PacketInfo("0x3B: [ClientTake] [DEC] ({hash}) {data}", packet.Hash(), packet.ToString());
 
                         if (packet.Opcode == 0x39 || packet.Opcode == 0x3A)
                             packet.DecryptDialog();
@@ -570,6 +577,8 @@ namespace Hybrasyl
                                 var throttleResult = Server.PacketThrottleCheck(this, packet);
                                 if (throttleResult == ThrottleResult.OK || throttleResult == ThrottleResult.ThrottleEnd || throttleResult == ThrottleResult.SquelchEnd)
                                 {
+                                    if (packet.Opcode == 0x3B)
+                                        GameLog.PacketInfo("0x3B: [ClientTake] [ENC] ({hash}) {data}", packet.Hash(), packet.ToString());
                                     World.MessageQueue.Add(new HybrasylClientMessage(packet, ConnectionId));
                                 }
                                 else

--- a/hybrasyl/Client.cs
+++ b/hybrasyl/Client.cs
@@ -150,8 +150,6 @@ namespace Hybrasyl
                     {
                         BytesReceived -= packetLength;
                         packet = new ClientPacket(ReceiveBufferPop(packetLength).ToArray());
-                        if (packet.Opcode == 0x3B)
-                            GameLog.PacketInfo("0x3B: [TryGetPacket] [ENC] ({hash}) {data}", packet.Hash(), packet.ToString());
                         return true;
                     }
                 }
@@ -537,18 +535,11 @@ namespace Hybrasyl
                     ClientPacket packet;
                     while (ClientState.ReceiveBufferTake(out packet))
                     {
-                        //GameLog.Info("Debug - packet before decryption");
-                        //packet.DumpPacket();
-                        if (packet.Opcode == 0x3B)
-                            GameLog.PacketInfo("0x3B: [ClientTake] [ENC] ({hash}) {data}", packet.Hash(), packet.ToString());
 
                         if (packet.ShouldEncrypt)
                         {
                             packet.Decrypt(this);
                         }
-
-                        if (packet.Opcode == 0x3B)
-                            GameLog.PacketInfo("0x3B: [ClientTake] [DEC] ({hash}) {data}", packet.Hash(), packet.ToString());
 
                         if (packet.Opcode == 0x39 || packet.Opcode == 0x3A)
                             packet.DecryptDialog();
@@ -580,8 +571,6 @@ namespace Hybrasyl
                                 var throttleResult = Server.PacketThrottleCheck(this, packet);
                                 if (throttleResult == ThrottleResult.OK || throttleResult == ThrottleResult.ThrottleEnd || throttleResult == ThrottleResult.SquelchEnd)
                                 {
-                                    if (packet.Opcode == 0x3B)
-                                        GameLog.PacketInfo("0x3B: [ClientTake] [ENC] ({hash}) {data}", packet.Hash(), packet.ToString());
                                     World.MessageQueue.Add(new HybrasylClientMessage(packet, ConnectionId));
                                 }
                                 else

--- a/hybrasyl/Enums.cs
+++ b/hybrasyl/Enums.cs
@@ -309,7 +309,8 @@ namespace Hybrasyl
             Scripting = 1,
             GmActivity = 2,
             UserActivity = 3,
-            Spawn = 4
+            Spawn = 4,
+            Packet = 5
         }
 
         public enum UserStatus : byte

--- a/hybrasyl/GameLog.cs
+++ b/hybrasyl/GameLog.cs
@@ -166,5 +166,7 @@ namespace Hybrasyl
         public static void SpawnDebug(Exception ex, string messageTemplate, params object[] propertyValues) => LogWithException(ex, LogEventLevel.Debug, LogType.Spawn, messageTemplate, propertyValues);
         public static void SpawnFatal(Exception ex, string messageTemplate, params object[] propertyValues) => LogWithException(ex, LogEventLevel.Fatal, LogType.Spawn, messageTemplate, propertyValues);
 
+        // Packet log
+        public static void PacketInfo(string messageTemplate, params object[] propertyValues) => Log(LogEventLevel.Information, LogType.Packet, messageTemplate, propertyValues);
     }
 }

--- a/hybrasyl/Packet.cs
+++ b/hybrasyl/Packet.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.IO;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace Hybrasyl
@@ -248,6 +249,14 @@ namespace Hybrasyl
         protected Packet()
         {
             TransmitDelay = 0;
+        }
+
+        private static SHA1CryptoServiceProvider hashAlgorithm = new SHA1CryptoServiceProvider();
+
+        public string Hash()
+        {
+            var hash = hashAlgorithm.ComputeHash(Data);
+            return BitConverter.ToString(hash).Substring(0, 8);          
         }
 
         public int Position

--- a/hybrasyl/Server.cs
+++ b/hybrasyl/Server.cs
@@ -219,6 +219,7 @@ namespace Hybrasyl
                     GameLog.Error($"bytesRead: {bytesRead}, errorCode: {errorCode}");
                     client.Disconnect();
                 }
+                client.ClientState.BytesReceived += bytesRead;
             }
             catch (Exception e)
             {
@@ -248,7 +249,7 @@ namespace Hybrasyl
             // Continue getting dem bytes
             try
             {
-                state.WorkSocket.BeginReceive(state.Buffer, 0, state.Buffer.Length, 0,
+                state.WorkSocket.BeginReceive(state.Buffer, state.BytesReceived, state.Buffer.Length, 0,
                     new AsyncCallback(this.ReadCallback), state);
                 GameLog.DebugFormat("Triggering receive callback");
             }

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -2961,13 +2961,9 @@ namespace Hybrasyl
         {
             var user = (User)obj;
             var response = new ServerPacket(0x31);
-            GameLog.PacketInfo("0x3b: [Handler] [DEC] ({hash}) {data}", packet.Hash(), packet.ToString());
 
             var action = packet.ReadByte();
             
-            GameLog.Error($"0x3B length is {packet.ToArray().Length}");
-            GameLog.Error($"0x3B action is {action}");
-
             // The moment we get a 3B packet, we assume a user is "in a board"
             user.Condition.Flags = user.Condition.Flags | PlayerFlags.InBoard;
 
@@ -4511,10 +4507,6 @@ namespace Hybrasyl
                     var clientMessage = (HybrasylClientMessage)message;
                     var handler = PacketHandlers[clientMessage.Packet.Opcode];
                     var timerOptions = HybrasylMetricsRegistry.OpcodeTimerIndex[clientMessage.Packet.Opcode];
-
-                    // Debug for board access issue 
-                    if (clientMessage.Packet.Opcode == 0x3b)
-                        GameLog.PacketInfo("0x3b: [WorldQueue] [DEC] ({hash}) {data}", clientMessage.Packet.Hash(), clientMessage.Packet.ToString());
 
                     try
                     {

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -4576,8 +4576,6 @@ namespace Hybrasyl
                                 PacketHandlers[clientMessage.Packet.Opcode].Invoke(user, clientMessage.Packet);
                                 watch.Stop();
                                 Game.MetricsStore.Measure.Timer.Time(timerOptions, watch.ElapsedMilliseconds);
-                                GameLog.Info($"opcode: {watch.ElapsedMilliseconds}");
-
                             }
                             else
                             {
@@ -4641,7 +4639,6 @@ namespace Hybrasyl
                         var timerOptions = HybrasylMetricsRegistry.ControlMessageTimerIndex[hcm.Opcode];
                         ControlMessageHandlers[hcm.Opcode].Invoke(hcm);
                         watch.Stop();
-                        GameLog.Info($"hcm: {watch.ElapsedMilliseconds}");
                         Game.MetricsStore.Measure.Timer.Time(timerOptions, watch.ElapsedMilliseconds);
                     }
                     catch (Exception e)


### PR DESCRIPTION
## Description
This PR fixes a packet processing issue that was only happening on fragmented packets (eg over Internet, > 1460 bytes). This updates the buffer to be correctly length checked and continually read into when the initial async read does not completely finish reading the entire packet off the socket.

## Impacted Areas in Hybrasyl
Literally all packet processing.
