### PR TITLE
OnDeath fixes

### DIFF
--- a/hybrasyl/Objects/Creature.cs
+++ b/hybrasyl/Objects/Creature.cs
@@ -871,6 +871,7 @@ namespace Hybrasyl.Objects
 
         public virtual void Damage(double damage, Xml.Element element = Xml.Element.None, Xml.DamageType damageType = Xml.DamageType.Direct, Xml.DamageFlags damageFlags = Xml.DamageFlags.None, Creature attacker = null, bool onDeath=true)
         {
+            if (this is Monster ms && !Condition.Alive) return;
             if (attacker is User && this is Monster)
             {
                 if (FirstHitter == null || !World.UserConnected(FirstHitter.Name) || ((DateTime.Now - LastHitTime).TotalSeconds > Constants.MONSTER_TAGGING_TIMEOUT)) FirstHitter = attacker;
@@ -911,10 +912,13 @@ namespace Hybrasyl.Objects
             Stats.Hp -= normalized;
 
             SendDamageUpdate(this);
-                        
+
             // TODO: Separate this out into a control message
             if (Stats.Hp == 0 && onDeath)
+            {
+                if (this is Monster) Condition.Alive = false;
                 OnDeath();
+            }
         }
 
         private void SendDamageUpdate(Creature creature)

--- a/hybrasyl/Objects/Monster.cs
+++ b/hybrasyl/Objects/Monster.cs
@@ -198,6 +198,7 @@ namespace Hybrasyl.Objects
         public bool DeathDisabled => _spawn.Flags.HasFlag(Xml.SpawnFlags.DeathDisabled);
         public bool MovementDisabled => _spawn.Flags.HasFlag(Xml.SpawnFlags.MovementDisabled);
         public bool AiDisabled => _spawn.Flags.HasFlag(Xml.SpawnFlags.AiDisabled);
+        public bool DeathProcessed { get; set; }
 
         public bool ScriptExists { get; set; }
 
@@ -228,7 +229,13 @@ namespace Hybrasyl.Objects
                 return;
             }
 
-            Condition.Alive = false;
+            // Don't die twice
+            if (DeathProcessed == true) return;
+
+            // Even if we encounter an error, we still count the death as processed to avoid 
+            // repeated processiong
+            DeathProcessed = true;
+
             var hitter = LastHitter as User;
             if (hitter == null)
             {
@@ -468,6 +475,7 @@ namespace Hybrasyl.Objects
                 ShouldWander = IsHostile == false;
 
             ThreatInfo = new ThreatInfo();
+            DeathProcessed = false;
         }
 
         public Creature Target

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -118,12 +118,12 @@ namespace Hybrasyl.Objects
             }
         }
 
-        public Mailbox Mailbox => World.GetMailbox(Name);
-        public Vault Vault => World.GetVault(AccountUuid ?? Uuid);
-        public ParcelStore ParcelStore => World.GetParcelStore(Uuid);
+        public Mailbox Mailbox => Game.World.GetMailbox(Name);
+        public Vault Vault => Game.World.GetVault(AccountUuid ?? Uuid);
+        public ParcelStore ParcelStore => Game.World.GetParcelStore(Uuid);
         public bool UnreadMail => Mailbox.HasUnreadMessages;
         public bool HasParcels => ParcelStore.Items.Count > 0;
-
+       
         #region Appearance settings 
         [JsonProperty]
         public RestPosition RestPosition { get; set; }

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -1863,7 +1863,7 @@ namespace Hybrasyl
         {
             var creature = (Objects.Creature)message.Arguments[0];
             if (creature is User u) { u.OnDeath(); }
-            if (creature is Monster ms) { ms.OnDeath(); }
+            if (creature is Monster ms && !ms.DeathProcessed) { ms.OnDeath(); }
         }
 
         


### PR DESCRIPTION
Don't allow further damage to be done to a mob at 0 hp
checks to not run ondeath twice (alive cannot be used for this purpose as alive has a different semantic meaning for users, since users have both alive/coma)
