### PR TITLE
Abstract authentication / login information from user object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,3 +292,6 @@ hybrasyl/articles
 hybrasyl/site
 hybrasyl/docfx.json
 hybrasyl/toc.yml
+
+# Redis dumps
+dump.rdb

--- a/.gitignore
+++ b/.gitignore
@@ -294,4 +294,4 @@ hybrasyl/docfx.json
 hybrasyl/toc.yml
 
 # Redis dumps
-dump.rdb
+*.rdb

--- a/hybrasyl/Game.cs
+++ b/hybrasyl/Game.cs
@@ -116,6 +116,7 @@ namespace Hybrasyl
 
         public static void CurrentDomain_ProcessExit(object sender, EventArgs e) => Shutdown();
 
+
         public static void Shutdown()
         {
             Log.Warning("Hybrasyl: all servers shutting down");
@@ -299,7 +300,7 @@ namespace Hybrasyl
                     
             if (!World.InitWorld())
             {
-                GameLog.Fatal("Hybrasyl cannot continue loading. Fatal error while loading world data. Press any key to exit.");
+                GameLog.Fatal("Hybrasyl cannot continue loading. A fatal error while initializing the world. Press any key to exit.");
                 Console.ReadKey();
                 Environment.Exit(1);
             }

--- a/hybrasyl/Hybrasyl.csproj
+++ b/hybrasyl/Hybrasyl.csproj
@@ -88,6 +88,10 @@
     <EmbeddedResource Include="Resources\sotp.dat" />
   </ItemGroup>
 
+  <ItemGroup>	
+    <EmbeddedResource Include="RedisMigrations\active.json"/>
+  </ItemGroup>
+
   <ItemGroup>
     <None Include="MetricsIncludes.cs">
       <DesignTime>True</DesignTime>
@@ -137,4 +141,10 @@
     </Compile>
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="RedisMigrations\Scripts\*.*">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/hybrasyl/Migrations.cs
+++ b/hybrasyl/Migrations.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hybrasyl
+{
+    // Some simple classes we can use to deserialize migration json.
+    [JsonObject]
+    class RedisMigrations
+    {
+        public List<string> Migrations { get; set; }
+    }
+
+    class RedisActiveMigrations
+    {
+        public List<string> ActiveMigrations { get; set; }
+    }
+}

--- a/hybrasyl/Objects/AuthInfo.cs
+++ b/hybrasyl/Objects/AuthInfo.cs
@@ -1,0 +1,78 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hybrasyl.Objects
+{
+    public enum UserState : byte
+    {
+        Disconnected = 0,
+        Login = 1,
+        Redirect = 2,
+        InWorld = 3
+    }
+
+    [JsonObject(MemberSerialization.OptIn)]
+    public class AuthInfo
+    {
+        [JsonProperty]
+        public string UserUuid { get; set; }
+
+        public bool IsLoggedIn => CurrentState == UserState.InWorld;
+
+        [JsonProperty]
+        public UserState CurrentState { get; set; }
+
+        [JsonProperty]
+        public DateTime LastStateChange { get; set; }
+
+        public double StateChangeDuration => (DateTime.Now - LastStateChange).TotalMilliseconds;
+
+        [JsonProperty]
+        public DateTime LastLogin { get; set; }
+        [JsonProperty]
+        public DateTime LastLogoff { get; set; }
+        [JsonProperty]
+        public DateTime LastLoginFailure { get; set; }
+        [JsonProperty]
+        public string LastLoginFrom { get; set; }
+        [JsonProperty]
+        public string LastLoginFailureFrom { get; set; }
+        [JsonProperty]
+        public Int64 LoginFailureCount { get; set; }
+        [JsonProperty]
+        public DateTime CreatedTime { get; set; }
+        [JsonProperty]
+        public bool FirstLogin { get; set; }
+        [JsonProperty]
+        public string PasswordHash { get; set; }
+        [JsonProperty]
+        public DateTime LastPasswordChange { get; set; }
+        [JsonProperty]
+        public string LastPasswordChangeFrom { get; set; }
+        public string StorageKey => string.Concat(GetType(), ':', UserUuid);
+        public bool IsSaving { get; set; }
+
+        public AuthInfo(string uuid)
+        {
+            UserUuid = uuid;
+        }
+
+        public void Save()
+        {
+            if (IsSaving) return;
+            IsSaving = true;
+            var cache = World.DatastoreConnection.GetDatabase();
+            cache.Set(StorageKey, this);
+            Game.World.WorldData.Set<AuthInfo>(UserUuid, this);
+            IsSaving = false;
+        }
+
+        public bool VerifyPassword(string password)
+        {
+            return BCrypt.Net.BCrypt.Verify(password, PasswordHash);
+        }
+
+    }
+}

--- a/hybrasyl/RedisMigrations/README.MD
+++ b/hybrasyl/RedisMigrations/README.MD
@@ -1,0 +1,32 @@
+# Redis Migrations
+
+Occasionally there are changes to serialized data structures that are
+too complex or error prone to be done live.  These scripts take care
+of those migrations.
+
+Generally these migrations are one-way, so you will want to backup
+Redis (eg copy `dump.rdb` / `appendonly.aof` from `/var/lib/redis` to
+a separate directory before running.
+
+## Adding Migrations
+
+Add the migration name to `active.json`. Hybrasyl's build process
+embeds this file as a resource, and it will be consulted for
+migrations needing to be run before server start. Hybrasyl will refuse
+to start unless all migrations are applied.
+
+Individual scripts go in `Scripts` in this directory. They should
+define a migration name that will be used to tell if the migration has
+run or not.
+
+Look at `Scripts/20200929-authinfo.py` for examples. Note that your migration
+must be idempotent.
+
+## Running Migrations
+
+Migrations will check to see if they have been run, and will not
+re-run.  It is safe to run them all any number of times using the
+included `run_migrations.sh` script in the `Scripts` directory.
+
+
+

--- a/hybrasyl/RedisMigrations/Scripts/20200929-authinfo.py
+++ b/hybrasyl/RedisMigrations/Scripts/20200929-authinfo.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python
+#
+#
+# Migrate all serialized users in a Hybrasyl Redis store to having a separate AuthInfo construct.
+#
+# Run with python 3, e.g. `python 20200929-authinfo.py`. Assumes running redis on localhost.
+#
+
+import redis
+import json
+import sys
+
+r = redis.Redis()
+
+MIGRATION_NAME = "20200929-authinfo"
+
+MIGRATION_FIELDS = {'LastLogin': 'Login',
+                    'LastLogoff': 'Login',
+                    'LastLoginFailure': 'Login',
+                    'LastLoginFrom': 'Login',
+                    'LoginFailureCount': 'Login',
+                    'CreatedTime': 'Login',
+                    'FirstLogin': 'Login'}
+
+migrations = r.get('Hybrasyl.RedisMigrations')
+
+if (migrations is not None):
+    migrations = json.loads(r.get('Hybrasyl.RedisMigrations'))
+    if MIGRATION_NAME in migrations['Migrations']:
+        print("This migration has already been applied.")
+        sys.exit()
+    migrations['Migrations'].append(MIGRATION_NAME)
+else:
+    migrations = {}
+    migrations['Migrations'] = [MIGRATION_NAME]
+
+r.set('Hybrasyl.RedisMigrations', json.dumps(migrations))
+    
+for userkey in r.keys("User:*"):
+    username = userkey.decode().split(':')[1]
+    authinfo = {}
+    userobj = json.loads(r.get(userkey))
+    print(f"{MIGRATION_NAME}: Running migration for {username}, uuid {userobj['Uuid']}")
+    for k,v in MIGRATION_FIELDS.items():
+        authinfo[k] = userobj[v][k]
+    # Handle fields that were renamed
+    authinfo['LastPasswordChange'] = userobj['Password']['LastChanged']
+    authinfo['LastPasswordChangeFrom'] = userobj['Password']['LastChangedFrom']
+    authinfo['PasswordHash'] = userobj['Password']['Hash']
+    authinfo['UserUuid'] = userobj['Uuid']   
+    userobj.pop('Password')
+    userobj.pop('Login')
+    authinfo_json = json.dumps(authinfo)
+    #print(authinfo_json)
+    authinfo_key = f"Hybrasyl.AuthInfo:{userobj['Uuid']}"
+    r.set(authinfo_key, authinfo_json)
+    print(f"{MIGRATION_NAME}: AuthInfo converted, saved {authinfo_key}")
+    r.set(username, json.dumps(userobj))
+    print(f"{MIGRATION_NAME}: User object for {username} pruned and saved")
+
+# Set the migration as having run
+
+migrations = json.loads(r.get('Hybrasyl.RedisMigrations'))
+migrations['Migrations'].append(MIGRATION_NAME)
+r.set('Hybrasyl.RedisMigrations', json.dumps(migrations))
+
+print(f"{MIGRATION_NAME}: Marked migration as complete")

--- a/hybrasyl/RedisMigrations/Scripts/run_migrations.sh
+++ b/hybrasyl/RedisMigrations/Scripts/run_migrations.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+
+echo -e "Running migrations...\n"
+
+PYTHON=$(which python)
+
+# check a few places
+if [[ -z "${PYTHON}" ]]; then
+   if [[ -e /usr/bin/python3 ]]; then
+       PYTHON=/usr/bin/python3
+   elif [[ -e /usr/local/bin/python3 ]]; then
+       PYTHON=/usr/local/bin/python3
+   fi
+fi
+
+echo "Checking ${PYTHON}"
+
+${PYTHON} -c 'import sys; exit(1) if sys.version_info.major < 3 else exit(0)'
+
+if [[ $? == 1 ]]; then
+    echo "Python 3 is required tom run migrations."
+    exit 1
+fi
+
+for x in *.py; do
+    echo -e "Running $x\n"
+    ${PYTHON} ${x}
+done
+

--- a/hybrasyl/RedisMigrations/active.json
+++ b/hybrasyl/RedisMigrations/active.json
@@ -1,0 +1,5 @@
+{
+    "ActiveMigrations": [
+	"20200929-authinfo"
+    ]
+}

--- a/hybrasyl/UuidReference.cs
+++ b/hybrasyl/UuidReference.cs
@@ -6,18 +6,11 @@ using System.Text;
 
 namespace Hybrasyl
 {
-    [JsonObject(MemberSerialization.OptIn)]
     public class UuidReference
     {
         private readonly object _lock = new object();
 
-        private string _name;
-        private string _userUuid;
-        private string _accountUuid;
-        private string _mailboxUuid;
-        private string _parcelStoreUuid;
-        private string _vaultUuid;
-
+        public string UserName { get; set; }
         
         public string UserUuid { get; set; }
         
@@ -28,15 +21,14 @@ namespace Hybrasyl
         public string ParcelStoreUuid { get; set; }
         
         public string MailboxUuid { get; set; }
+
+        public string AuthInfoUuid { get; set; }
         
-
-        //public string StorageKey => string.Concat(GetType(), ':', _name);
-
         public UuidReference() { }
 
         public UuidReference(string name)
         {
-            _name = name;
+            UserName = name;
         }
 
         

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -847,7 +847,7 @@ namespace Hybrasyl
                 };
 
                 //sanity check to make sure user has this object
-                if (!WorldData.ContainsKey<ParcelStore>($"Hybrasyl.ParcelStore:{uuidRef.UserUuid}"))
+                if (!WorldData.ContainsKey<ParcelStore>(uuidRef.UserUuid))
                 {
                     GameLog.InfoFormat("No parcelstore found for {0}, creating", name);
                     var parcelStore = new ParcelStore(uuidRef.UserUuid);

--- a/hybrasyl/grpc/PatronServer.cs
+++ b/hybrasyl/grpc/PatronServer.cs
@@ -97,9 +97,9 @@ namespace HybrasylGrpc
         {
             try
             {
-                if (World.TryGetUser(request.Username, out User user))
+                if (Game.World.TryGetAuthInfo(request.Username, out AuthInfo login))
                 {
-                    if (user.VerifyPassword(request.Password))
+                    if (login.VerifyPassword(request.Password))
                         return Task.FromResult(new BooleanMessageReply() { Message = "", Success = true });
                 }
                 else
@@ -116,22 +116,21 @@ namespace HybrasylGrpc
         {
             try
             {
-                // Simple length check
-                if (request.NewPassword.Length > 8 || request.NewPassword.Length < 4)
-                    return Task.FromResult(new BooleanMessageReply() { Message = "Passwords must be between 4 and 8 characters", 
-                        Success = false });
-
-                if (Game.World.UserConnected(request.Username))
-                    return Task.FromResult(new BooleanMessageReply() { Message = "User is currently logged in", 
-                        Success = false });
-
-                if (World.TryGetUser(request.Username, out User user))
+                if (Game.World.TryGetAuthInfo(request.Username, out AuthInfo login))
                 {
-                    user.Password.Hash = BCrypt.Net.BCrypt.HashPassword(request.NewPassword,
+                    // Simple length check
+                    if (request.NewPassword.Length > 8 || request.NewPassword.Length < 4)
+                        return Task.FromResult(new BooleanMessageReply()
+                        {
+                            Message = "Passwords must be between 4 and 8 characters",
+                            Success = false
+                        });
+
+                    login.PasswordHash = BCrypt.Net.BCrypt.HashPassword(request.NewPassword,
                         BCrypt.Net.BCrypt.GenerateSalt(12));
-                    user.Password.LastChanged = DateTime.Now;
-                    user.Password.LastChangedFrom = context.Peer;
-                    user.Save();
+                    login.LastPasswordChange = DateTime.Now;
+                    login.LastPasswordChangeFrom = context.Peer;
+                    login.Save();
                 }
                 else
                     return Task.FromResult(new BooleanMessageReply() { Message = "Unknown user", Success = false });


### PR DESCRIPTION
## Description
This PR creates a new UUID-linked `AuthInfo` object which replaces the previous `PasswordInfo` and `LoginInfo` structures. This is now separate from user, which means it can be manipulated, checked, and saved without deserializing a user and potentially causing problems when we serialize back to Redis.

This also introduces a new Redis migration mechanism for making changes to stored data structures. This is intended to be run to migrate old data structures in Redis to new, updated formats without requiring wipes.

Hybrasyl will now check for migrations (`RedisMigrations\active.json` is embedded as a resource) on startup and refuse to start if migrations are not applied. The applied migrations are stored in Redis in a simple JSON list.

In addition we now keep track of client / player state in `AuthInfo` meaning checks for double logins are now much more robust. In particular we are now able to correctly handle the issue of simultaneous logins in a much better and more correct way, and can tell when someone is redirecting vs actually in world.

## Impacted Areas in Hybrasyl
Login, authentication

p.s. I still need to correct a few typos, this is not ready for merging yet