### PR TITLE
Hybrasyl 0.9.1

### DIFF
--- a/HybrasylTests/Fixtures.cs
+++ b/HybrasylTests/Fixtures.cs
@@ -162,6 +162,9 @@ public class HybrasylFixture : IDisposable
             BaseAc = 100,
         };
         TestUser.Class = Class.Peasant;
+        TestUser.Inventory.Clear();
+        TestUser.Equipment.Clear();
+        TestUser.Vault.Clear();
     }
 
     public void Dispose()

--- a/HybrasylTests/Items.cs
+++ b/HybrasylTests/Items.cs
@@ -17,6 +17,11 @@ public class Items
     }
 
     [Fact]
+    public void ItemSlotRestrictions()
+    {
+
+    }
+    [Fact]
     public void UseItemBaseStats()
     {
         Fixture.TestUser.Equipment.Clear();

--- a/HybrasylTests/Merchant.cs
+++ b/HybrasylTests/Merchant.cs
@@ -114,7 +114,7 @@ public class Merchants
     {
         Fixture.ResetUserStats();
         Fixture.TestUser.Teleport("XUnit Test Realm", 8, 8);
-        Assert.True(Game.World.WorldData.TryGetValueByIndex("Epee", out Item junk), "Couldn't find prayer book in test items");
+        Assert.True(Game.World.WorldData.TryGetValueByIndex("Epee", out Item junk), "Couldn't find epee in test items");
         var item = new ItemObject(junk, Fixture.TestUser.World.Guid);
         Fixture.TestUser.AddItem(item);
         var before = Fixture.TestUser.Stats.Gold;
@@ -131,7 +131,7 @@ public class Merchants
     {
         Fixture.ResetUserStats();
         Fixture.TestUser.Teleport("XUnit Test Realm", 8, 8);
-        Assert.True(Game.World.WorldData.TryGetValueByIndex("Epee", out Item junk), "Couldn't find prayer book in test items");
+        Assert.True(Game.World.WorldData.TryGetValueByIndex("Epee", out Item junk), "Couldn't find epee in test items");
         var before = Fixture.TestUser.Stats.Gold;
         var item = new ItemObject(junk, Fixture.TestUser.World.Guid);
         Fixture.TestUser.AddItem(item);
@@ -139,10 +139,41 @@ public class Merchants
         Fixture.TestUser.AddItem(item2);
         item.Durability /= 2;
         item2.Durability /= 2;
+        Fixture.TestUser.Stats.Gold = 1;
         Fixture.TestUser.Say("repair all");
         var msg = Fixture.TestUser.MessagesReceived.Last();
         Assert.Equal("Maria", msg.Speaker.Name);
-        Assert.Equal($"Certainly. I will buy 1 of those for {item.Value} coins, {Fixture.TestUser.Name}.", msg.Message);
+        Assert.Equal($"You'll need 250 more gold to repair all of it, I'm afraid.", msg.Message);
+        Fixture.TestUser.Stats.Gold = 10000;
+        Fixture.TestUser.Say("repair all");
+        msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.True(item.Durability == item.MaximumDurability);
+        Assert.True(item2.Durability == item2.MaximumDurability);
+        Assert.Equal($"I repaired it all for 1000 coins.", msg.Message);
+    }
+
+    [Fact]
+    public void RepairItem()
+    {
+        Fixture.ResetUserStats();
+        Fixture.TestUser.Teleport("XUnit Test Realm", 8, 8);
+        Assert.True(Game.World.WorldData.TryGetValueByIndex("Epee", out Item junk), "Couldn't find epee in very test items");
+        var before = Fixture.TestUser.Stats.Gold;
+        var item = new ItemObject(junk, Fixture.TestUser.World.Guid);
+        Fixture.TestUser.AddItem(item);
+        item.Durability /= 2;
+        Fixture.TestUser.Stats.Gold = 1;
+        Fixture.TestUser.Say("repair my epee");
+        var msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal($"You'll need 250 more gold to repair that, I'm afraid.", msg.Message);
+        Fixture.TestUser.Stats.Gold = 10000;
+        Fixture.TestUser.Say("repair my epee");
+        msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.True(item.Durability == item.MaximumDurability);
+        Assert.Equal($"I repaired your Epee for 250 coins.", msg.Message);
     }
 
     [Fact]
@@ -179,6 +210,7 @@ public class Merchants
         Fixture.TestUser.Teleport("XUnit Test Realm", 8, 8);
         Assert.True(Game.World.WorldData.TryGetValueByIndex("Epee", out Item junk), "Couldn't find prayer book in test items");
         var item = new ItemObject(junk, Fixture.TestUser.World.Guid);
+        item.Durability = item.MaximumDurability;
         Fixture.TestUser.AddItem(item);
         Fixture.TestUser.Say("deposit epee");
         var msg = Fixture.TestUser.MessagesReceived.Last();

--- a/HybrasylTests/Merchant.cs
+++ b/HybrasylTests/Merchant.cs
@@ -1,0 +1,241 @@
+﻿using System.Diagnostics;
+using System.Linq;
+using Hybrasyl;
+using Hybrasyl.Objects;
+using Hybrasyl.Xml;
+using Xunit;
+
+namespace HybrasylTests;
+
+[Collection("Hybrasyl")]
+public class Merchants
+{
+    public HybrasylFixture Fixture { get; set; }
+
+    public Merchants(HybrasylFixture fixture)
+    {
+        Fixture = fixture;
+    }
+
+    [Fact]
+    public void CheckOnDeposit()
+    {
+        Fixture.ResetUserStats();
+        Fixture.TestUser.Teleport("XUnit Test Realm", 8, 8);
+        Fixture.TestUser.Say("how many epee do i have on deposit");
+        var msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal("You have none of those deposited.", msg.Message);
+        Assert.True(Game.World.WorldData.TryGetValueByIndex("Epee", out Item epee), "Couldn't find epee in test items");
+        var item = new ItemObject(epee, Fixture.TestUser.World.Guid);
+        item.Durability = item.MaximumDurability - 1;
+        Assert.True(Fixture.TestUser.AddItem(item), "Couldn't add item to inventory");
+        // Should refuse ("I don't want your junk...")
+        Fixture.TestUser.Say("deposit epee");
+        msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal("I don't want your junk. Ask a smith to fix it.", msg.Message);
+        item.Durability = item.MaximumDurability;
+        // Should now be depositable - except we have no money
+        Fixture.TestUser.Stats.Gold = 0;
+        Fixture.TestUser.Say("deposit epee");
+        msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal("I'll need 50 coins to deposit that.", msg.Message);
+        // Now we can deposit
+        Fixture.TestUser.Stats.Gold = 1000;
+        Fixture.TestUser.Say("deposit epee");
+        msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal("Epee, that'll be 50 coins.", msg.Message);
+        // Now we should have exactly one epee
+        Fixture.TestUser.Say("how many epee do i have on deposit");
+        msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal("You have 1 of those deposited.", msg.Message);
+    }
+
+    [Fact]
+    public void CheckGoldOnDeposit()
+    {
+        Fixture.ResetUserStats();
+        Fixture.TestUser.Teleport("XUnit Test Realm", 8, 8);
+        Fixture.TestUser.Say("how much gold do i have on deposit");
+        var msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal("You have no coins on deposit.", msg.Message);
+        // Now with gold
+        Fixture.TestUser.Stats.Gold = 100000;
+        Fixture.TestUser.Say("deposit 30000 gold");
+        msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal("I'll take your 30000 coins.", msg.Message);
+        // How much we got
+        Fixture.TestUser.Say("how much gold do i have on deposit");
+        msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal("You have 30000 coins on deposit.", msg.Message);
+        // Take it out, check again
+        Fixture.TestUser.Say("withdraw 29999 coins");
+        msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal("Here are your 29999 coins.", msg.Message);
+        Fixture.TestUser.Say("how much gold do i have on deposit");
+        msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal("You have 1 coin on deposit.", msg.Message);
+    }
+
+    [Fact]
+    public void BuyAllCategory()
+    {
+        Fixture.ResetUserStats();
+        var before = Fixture.TestUser.Stats.Gold;
+        Fixture.TestUser.Teleport("XUnit Test Realm", 8, 8);
+        Assert.True(Game.World.WorldData.TryGetValueByIndex("Prayer Book", out Item junk), "Couldn't find prayer book in test items");
+        var item = new ItemObject(junk, Fixture.TestUser.World.Guid);
+        item.Count = item.MaximumStack;
+        Fixture.TestUser.AddItem(item);
+        Assert.True(Game.World.WorldData.TryGetValueByIndex("Bent Needle", out Item junk2), "Couldn't find bent needle in test items");
+        var item2 = new ItemObject(junk, Fixture.TestUser.World.Guid);
+        item2.Count = item2.MaximumStack;
+        Fixture.TestUser.AddItem(item2);
+        Fixture.TestUser.Say("Buy all of my junk");
+        var msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        var coins = item.Value * item.Count + item2.Value * item2.Count;
+        Assert.Equal($"Certainly. That will be {coins} coins, TestUser.", msg.Message);
+        Assert.Equal(Fixture.TestUser.Stats.Gold, before + coins);
+        Assert.False(Fixture.TestUser.Inventory.ContainsName("Prayer Book"));
+    }
+
+    [Fact]
+    public void BuyItem()
+    {
+        Fixture.ResetUserStats();
+        Fixture.TestUser.Teleport("XUnit Test Realm", 8, 8);
+        Assert.True(Game.World.WorldData.TryGetValueByIndex("Epee", out Item junk), "Couldn't find prayer book in test items");
+        var item = new ItemObject(junk, Fixture.TestUser.World.Guid);
+        Fixture.TestUser.AddItem(item);
+        var before = Fixture.TestUser.Stats.Gold;
+        Fixture.TestUser.Say("Buy 1 of my epee");
+        var msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal($"Certainly. I will buy 1 of those for {item.Value} coins, {Fixture.TestUser.Name}.", msg.Message);
+        Assert.Equal(Fixture.TestUser.Stats.Gold, before + item.Value);
+        Assert.False(Fixture.TestUser.Inventory.ContainsName("Epee"));
+    }
+
+    [Fact]
+    public void RepairAll()
+    {
+        Fixture.ResetUserStats();
+        Fixture.TestUser.Teleport("XUnit Test Realm", 8, 8);
+        Assert.True(Game.World.WorldData.TryGetValueByIndex("Epee", out Item junk), "Couldn't find prayer book in test items");
+        var before = Fixture.TestUser.Stats.Gold;
+        var item = new ItemObject(junk, Fixture.TestUser.World.Guid);
+        Fixture.TestUser.AddItem(item);
+        var item2 = new ItemObject(junk, Fixture.TestUser.World.Guid);
+        Fixture.TestUser.AddItem(item2);
+        item.Durability /= 2;
+        item2.Durability /= 2;
+        Fixture.TestUser.Say("repair all");
+        var msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal($"Certainly. I will buy 1 of those for {item.Value} coins, {Fixture.TestUser.Name}.", msg.Message);
+    }
+
+    [Fact]
+    public void DepositGold()
+    {
+        Fixture.ResetUserStats();
+        Fixture.TestUser.Teleport("XUnit Test Realm", 8, 8);
+        Fixture.TestUser.Say("how much gold do i have on deposit");
+        var msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal("You have no coins on deposit.", msg.Message);
+        // Not enough gold
+        Fixture.TestUser.Say("deposit 30000 gold");
+        msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal("You don't have that much.", msg.Message);
+        Fixture.TestUser.Stats.Gold = 100000;
+        Fixture.TestUser.Say("deposit 30000 gold");
+        msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal("I'll take your 30000 coins.", msg.Message);
+        // How much we got
+        Fixture.TestUser.Say("how much gold do i have on deposit");
+        msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal("You have 30000 coins on deposit.", msg.Message);
+        Assert.Equal(Fixture.TestUser.Stats.Gold, (uint) 70000);
+    }
+
+    [Fact]
+    public void DepositItem()
+    {
+        Fixture.ResetUserStats();
+        Fixture.TestUser.Teleport("XUnit Test Realm", 8, 8);
+        Assert.True(Game.World.WorldData.TryGetValueByIndex("Epee", out Item junk), "Couldn't find prayer book in test items");
+        var item = new ItemObject(junk, Fixture.TestUser.World.Guid);
+        Fixture.TestUser.AddItem(item);
+        Fixture.TestUser.Say("deposit epee");
+        var msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal("Epee, that'll be 50 coins.", msg.Message);
+        Assert.False(Fixture.TestUser.Inventory.ContainsName("Epee"));
+        Assert.True(Fixture.TestUser.Vault.Items.ContainsKey("Epee"));
+        Assert.Equal(Fixture.TestUser.Vault.Items["Epee"], (uint) 1);
+
+    }
+
+    [Fact]
+    public void WithdrawGold()
+    {
+        Fixture.ResetUserStats();
+        Fixture.TestUser.Teleport("XUnit Test Realm", 8, 8);
+        var before = Fixture.TestUser.Stats.Gold;
+        Fixture.TestUser.Vault.AddGold(30000);
+        Fixture.TestUser.Say("withdraw 30000 coins");
+        var msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal("Here are your 30000 coins.", msg.Message);
+        Assert.Equal(Fixture.TestUser.Vault.CurrentGold, (uint) 0);
+        Assert.Equal(Fixture.TestUser.Stats.Gold, before + 30000);
+    }
+
+    [Fact]
+    public void WithdrawItem()
+    {
+        Fixture.ResetUserStats();
+        Fixture.TestUser.Teleport("XUnit Test Realm", 8, 8);
+        Assert.True(Game.World.WorldData.TryGetValueByIndex("Epee", out Item junk), "Couldn't find epee in test items");
+        var item = new ItemObject(junk, Fixture.TestUser.World.Guid);
+        Fixture.TestUser.AddItem(item);
+        Fixture.TestUser.Vault.AddItem(item.Name);
+
+    }
+
+    [Fact]
+    public void WithdrawStackableItem()
+    {
+        Fixture.ResetUserStats();
+        Fixture.TestUser.Teleport("XUnit Test Realm", 8, 8);
+        Assert.True(Game.World.WorldData.TryGetValueByIndex("Bent Needle", out Item junk), "Couldn't find bent needle in test items");
+        var item = new ItemObject(junk, Fixture.TestUser.World.Guid);
+        item.Count = item.MaximumStack - 1;
+        Fixture.TestUser.AddItem(item);
+        var item2 = new ItemObject(junk, Fixture.TestUser.World.Guid);
+        Fixture.TestUser.Vault.AddItem(item2.Name, (ushort) item2.Count);
+        Fixture.TestUser.Say("withdraw bent needle");
+        var msg = Fixture.TestUser.MessagesReceived.Last();
+        Assert.Equal("Maria", msg.Speaker.Name);
+        Assert.Equal("Here's your Bent Needle back.", msg.Message);
+        Assert.Equal(item.Count, item.MaximumStack);
+    }
+
+}
+
+
+

--- a/HybrasylTests/Monster.cs
+++ b/HybrasylTests/Monster.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Hybrasyl;
+﻿using Hybrasyl;
 using Hybrasyl.Objects;
 using Hybrasyl.Xml;
-using Microsoft.VisualBasic;
 using Xunit;
 using Creature = Hybrasyl.Xml.Creature;
 

--- a/HybrasylTests/Monster.cs
+++ b/HybrasylTests/Monster.cs
@@ -139,7 +139,7 @@ public class Monsters
     [Fact]
     public void MonsterThresholdRotations()
     {
-        // We need our gabbaghoulidk may
+        // We need our gabbaghoul
         Assert.True(Game.World.WorldData.TryGetValue<Creature>("Gabbaghoul", out var monsterXml),
             "Gabbaghoul test monster not found");
         var monster = new Monster(monsterXml, SpawnFlags.AiDisabled, 99);
@@ -154,7 +154,7 @@ public class Monsters
         entry2.Use();
         var maxHp = monster.Stats.MaximumHp;
         monster.Damage(monster.Stats.MaximumHp - 50);
-        Assert.True(monster.Stats.Hp == maxHp - 50);
+        Assert.True(monster.Stats.Hp == 50, $"hp should be 50 but is {monster.Stats.Hp}");
         entry2 = monster.CastableController.GetNextCastable();
         // This should be a threshold cast, but can be any of three spells at random
         Assert.NotNull(entry2);

--- a/HybrasylTests/Statuses.cs
+++ b/HybrasylTests/Statuses.cs
@@ -1,4 +1,6 @@
-﻿using Xunit;
+﻿using System.Linq;
+using Hybrasyl;
+using Xunit;
 
 namespace HybrasylTests;
 
@@ -6,13 +8,26 @@ namespace HybrasylTests;
 [Collection("Hybrasyl")]
 public class Status
 {
-    private static HybrasylFixture Fixture;
+    public HybrasylFixture Fixture { get; set; }
+
+    public Status(HybrasylFixture fixture)
+    {
+        Fixture = fixture;
+    }
 
     [Fact]
     public void ApplyStatus()
     {
         // Apply a status, verify that status exists
+        var castable = Game.World.WorldData.FindCastables(x => x.Name == "Plus AC").FirstOrDefault();
+        Fixture.TestUser.Stats.BaseMp = 1000;
+        Fixture.TestUser.Stats.Mp = 1000;
 
+        Assert.NotNull(castable);
+        Fixture.TestUser.SpellBook.Add(castable);
+        var beforeAc = Fixture.TestUser.Stats.Ac;
+        Fixture.TestUser.UseCastable(castable, Fixture.TestUser);
+        Assert.True(Fixture.TestUser.Stats.Ac == beforeAc + 20, $"ac should be {beforeAc+20} but is {Fixture.TestUser.Stats.Ac}");
     }
 
     [Fact]

--- a/HybrasylTests/Statuses.cs
+++ b/HybrasylTests/Statuses.cs
@@ -19,15 +19,14 @@ public class Status
     public void ApplyStatus()
     {
         // Apply a status, verify that status exists
-        var castable = Game.World.WorldData.FindCastables(x => x.Name == "Plus AC").FirstOrDefault();
         Fixture.TestUser.Stats.BaseMp = 1000;
         Fixture.TestUser.Stats.Mp = 1000;
-
+        var beforeAc = Fixture.TestUser.Stats.Ac;
+        var castable = Game.World.WorldData.FindCastables(x => x.Name == "Plus AC").FirstOrDefault();
         Assert.NotNull(castable);
         Fixture.TestUser.SpellBook.Add(castable);
-        var beforeAc = Fixture.TestUser.Stats.Ac;
         Fixture.TestUser.UseCastable(castable, Fixture.TestUser);
-        Assert.True(Fixture.TestUser.Stats.Ac == beforeAc + 20, $"ac should be {beforeAc+20} but is {Fixture.TestUser.Stats.Ac}");
+        Assert.True(Fixture.TestUser.Stats.Ac == beforeAc - 20, $"ac should be {beforeAc-20} but is {Fixture.TestUser.Stats.Ac}");
     }
 
     [Fact]

--- a/XML/XML.csproj
+++ b/XML/XML.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Hybrasyl.Xml</AssemblyName>
     <RootNamespace>Hybrasyl.Xml</RootNamespace>
-    <PackageVersion>0.8.0</PackageVersion>
-    <Version>0.8.0</Version>
+    <PackageVersion>0.9.0</PackageVersion>
+    <Version>0.9.0</Version>
     <BuildDocFx Condition="'$(Configuration)'=='Debug'">false</BuildDocFx>
   </PropertyGroup>
 

--- a/XML/XML.csproj
+++ b/XML/XML.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Hybrasyl.Xml</AssemblyName>
     <RootNamespace>Hybrasyl.Xml</RootNamespace>
-    <PackageVersion>0.9.0</PackageVersion>
-    <Version>0.9.0</Version>
+    <PackageVersion>0.9.1</PackageVersion>
+    <Version>0.9.1</Version>
     <BuildDocFx Condition="'$(Configuration)'=='Debug'">false</BuildDocFx>
   </PropertyGroup>
 

--- a/XML/XSD/Castable.xsd
+++ b/XML/XSD/Castable.xsd
@@ -91,12 +91,13 @@
       <xs:element name="Items" minOccurs="0" maxOccurs="1" type="hyb:ItemsSpecification" />
       <xs:element name="Stat" minOccurs="0" maxOccurs="1">
         <xs:complexType>
-          <!-- hp/mp can be expressed as percentages here -->
+          <!-- these attributes can be formulas -->
           <xs:attribute name="Hp" type="hyb:String8" default="0" />
           <xs:attribute name="Mp" type="hyb:String8" default="0" />
         </xs:complexType>
       </xs:element>
-      <xs:element name="Gold" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" />
+      <!-- Also can be a formula -->
+      <xs:element name="Gold" type="hyb:String8" minOccurs="0" maxOccurs="1" />
     </xs:sequence>
   </xs:complexType>
 

--- a/XML/XSD/Extensions/Item.cs
+++ b/XML/XSD/Extensions/Item.cs
@@ -106,6 +106,13 @@ public partial class Item
         return string.Concat(hash.Select(b => b.ToString("x2")))[..8];
     }
 
+    public IEnumerable<SlotRestriction> SlotRequirements =>
+        (Properties.Restrictions?.SlotRestrictions ?? new List<SlotRestriction>()).Where(x =>
+            x.Type == SlotRestrictionType.ItemRequired);
+    public IEnumerable<SlotRestriction> SlotProhibits =>
+        (Properties.Restrictions?.SlotRestrictions ?? new List<SlotRestriction>()).Where(x =>
+            x.Type == SlotRestrictionType.ItemProhibited);
+
     public string Id => GenerateId(Name, Gender);
 
     public Item Clone()

--- a/XML/XSD/Extensions/LootList.cs
+++ b/XML/XSD/Extensions/LootList.cs
@@ -4,6 +4,9 @@ namespace Hybrasyl.Xml;
 
 public partial class LootList
 {
+    public bool IsEmpty =>
+        (Set is null || Set.Count == 0) && (Table is null || Table.Count == 0) && (Gold is null) && Xp == 0;
+
     public static LootList operator +(LootList l1, LootList l2)
     {
         var ret = new LootList();

--- a/XML/XSD/Objects/ClassCastCost.cs
+++ b/XML/XSD/Objects/ClassCastCost.cs
@@ -30,7 +30,7 @@ public partial class ClassCastCost
     #region Private fields
     private List<ItemSpecification> _items;
     private ClassCastCostStat _stat;
-    private uint _gold;
+    private string _gold;
     private static XmlSerializer _serializerXml;
     #endregion
     
@@ -59,7 +59,8 @@ public partial class ClassCastCost
         }
     }
     
-    public uint Gold
+    [StringLengthAttribute(255, MinimumLength=1)]
+    public string Gold
     {
         get
         {

--- a/XML/XSD/Objects/SpawnGroup.cs
+++ b/XML/XSD/Objects/SpawnGroup.cs
@@ -28,6 +28,7 @@ public partial class SpawnGroup
 {
     #region Private fields
     private List<Spawn> _spawns;
+    private LootList _loot;
     private string _baseLevel;
     private bool _disabled;
     private string _name;
@@ -49,6 +50,18 @@ public partial class SpawnGroup
         set
         {
             _spawns = value;
+        }
+    }
+    
+    public LootList Loot
+    {
+        get
+        {
+            return _loot;
+        }
+        set
+        {
+            _loot = value;
         }
     }
     

--- a/XML/XSD/Spawns.xsd
+++ b/XML/XSD/Spawns.xsd
@@ -34,7 +34,8 @@
   <xs:complexType name="SpawnGroup">
     <xs:sequence>
       <xs:element name="Spawns" type="hyb:Spawns" minOccurs="0" maxOccurs="1"/>
-    </xs:sequence>
+      <xs:element name="Loot" type="hyb:LootList" minOccurs="0" maxOccurs="1"/>
+	</xs:sequence>
     <xs:attribute name="BaseLevel" type="xs:string" use="optional"/>
     <xs:attribute name="Disabled" type="xs:boolean" default="false"/>
     <xs:attribute name="Name" type="xs:string" use="optional"/>

--- a/hybrasyl/ChatCommands/Eval.cs
+++ b/hybrasyl/ChatCommands/Eval.cs
@@ -139,6 +139,7 @@ public static class EvalCommand
         {
             loot += LootBox.CalculateLoot(spawn.Loot);
             loot += LootBox.CalculateLoot(creature.Loot);
+            loot += LootBox.CalculateLoot(group.Loot);
         }
 
         return Success($"Eval for: {group.Name} - {spawn.Name}, {numEvals} rolls\n{loot}", MessageType.SlateScrollbar);

--- a/hybrasyl/ChatCommands/Eval.cs
+++ b/hybrasyl/ChatCommands/Eval.cs
@@ -1,12 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using System.Threading;
-using Grpc.Core;
-using Hybrasyl.Casting;
 using Hybrasyl.Objects;
 using Hybrasyl.Xml;
 using Creature = Hybrasyl.Objects.Creature;

--- a/hybrasyl/ChatCommands/Eval.cs
+++ b/hybrasyl/ChatCommands/Eval.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading;
+using Grpc.Core;
+using Hybrasyl.Casting;
+using Hybrasyl.Objects;
+using Hybrasyl.Xml;
+using Creature = Hybrasyl.Objects.Creature;
+
+namespace Hybrasyl.ChatCommands;
+
+public class RegexTrigger : Attribute
+{
+    public string Trigger;
+
+    public RegexTrigger(string trigger)
+    {
+        Trigger = trigger;
+    }
+}
+
+public class UsageText : Attribute
+{
+    public string Text;
+    public UsageText(string text)
+    {
+        Text = text;
+    }
+}
+
+public class WhisperTarget : Attribute
+{
+    public string Target;
+
+    public WhisperTarget(string target)
+    {
+        Target = target;
+    }
+}
+
+public class CommandResult
+{
+    public bool Success = false;
+    public bool ParseError = false;
+    public string Response = string.Empty;
+    public MessageType MessageType = MessageType.System;
+}
+
+public class EvalSubcommand
+{
+     public Func<User, Match, CommandResult> Delegate;
+     public string UsageText;
+}
+
+// POC for potential improvements to chat commands / command parsing
+
+[WhisperTarget("#")]
+public static class EvalCommand
+{
+
+    public static CommandResult Success(string response, MessageType type = MessageType.System) => 
+        new() { Success = true, Response = response, MessageType = type };
+
+    public static CommandResult Fail(string response, MessageType type = MessageType.System) =>
+        new() { Success = false, Response = response, MessageType = type };
+
+    private static Dictionary<Regex, EvalSubcommand> CommandRegexes = new();
+
+    private static string UsageTexts => string.Join("\n", CommandRegexes.Values.Select(x => x.UsageText));
+
+    static EvalCommand()
+    {
+        foreach (var method in typeof(EvalCommand).GetMethods(BindingFlags.Public|BindingFlags.Static))
+        {
+            var attr = method.GetCustomAttribute<RegexTrigger>();
+            if (attr == null) continue;
+            var regex = new Regex(attr.Trigger);
+            var cmd = new EvalSubcommand
+            {
+                Delegate = (Func<User, Match, CommandResult>) Delegate.CreateDelegate(
+                    typeof(Func<User, Match, CommandResult>), method)
+            };
+            var attr2 = method.GetCustomAttribute<UsageText>();
+            if (attr2 != null)
+                cmd.UsageText = attr2.Text;
+            CommandRegexes.Add(regex, cmd);
+        }
+    }
+
+    public static void Evaluate(string input, User user)
+    {
+        foreach (var (key, value) in CommandRegexes)
+        {
+            var matches = key.Match(input);
+            if (!matches.Success) continue;
+            var result = value.Delegate(user, matches);
+            if (result.ParseError)
+            {
+                user.DisplayIncomingWhisper("#", value.UsageText);
+                return;
+            }
+
+            if (!result.Success)
+            {
+                user.DisplayIncomingWhisper("#", $"ERR: {result.Response}");
+                return;
+            }
+
+            user.SendMessage(result.Response, result.MessageType);
+            return;
+        }
+
+        user.SendMessage("Usage:\n" + string.Join(",", UsageTexts), MessageType.SlateScrollbar); 
+    }
+
+    [RegexTrigger(@"evalloot ""(?<spawngroup>.+)"" ""(?<spawn>.+)"" (?<numevals>\d+)")]
+    [UsageText("evalloot <spawngroup name> <spawn name> <number of evals>")]
+    public static CommandResult EvalLoot(User user, Match match)
+    {
+        if (!Game.World.WorldData.TryGetValue(match.Groups["spawngroup"].Value, out SpawnGroup group))
+            return Fail("spawngroup not found");
+        if (!int.TryParse(match.Groups["numevals"].Value, out var numEvals))
+            return Fail("couldn't parse number of evals");
+
+        var spawn = group.Spawns.FirstOrDefault(x => x.Name == match.Groups["spawn"].Value);
+
+        if (spawn == null)
+            return Fail($"Group {group.Name} was found, but not spawn {match.Groups["spawn"].Value}");
+
+        if (!Game.World.WorldData.TryGetValue(spawn.Name, out Xml.Creature creature))
+            return Fail($"Inexplicably, spawngroup and spawn exist but not the creature {spawn.Name}");
+
+        var loot = new Loot(0, 0);
+        for (var x = 0; x <= numEvals; x++)
+        {
+            loot += LootBox.CalculateLoot(spawn.Loot);
+            loot += LootBox.CalculateLoot(creature.Loot);
+        }
+
+        return Success($"Eval for: {group.Name} - {spawn.Name}, {numEvals} rolls\n{loot}", MessageType.SlateScrollbar);
+    }
+
+    [RegexTrigger(@"evallootset ""(?<target>.+)"" (?<numrolls>\d+)")]
+    [UsageText("evallootset <lootset name> <number of rolls>")]
+    public static CommandResult EvalLootset(User user, Match match)
+    {
+        if (!int.TryParse(match.Groups["numrolls"].Value, out var numEvals))
+            return Fail("couldn't parse number of rolls");
+
+        if (!Game.World.WorldData.TryGetValueByIndex(match.Groups["target"].Value, out LootSet set))
+            return Fail("lootset not found, or bad number of rolls");
+
+        var loot = LootBox.CalculateLoot(set, numEvals, 1);
+        return Success($"Eval for: {set.Name}, {numEvals} rolls\n{loot}", MessageType.SlateScrollbar);
+    }
+
+    [RegexTrigger(@"eval ""(?<castable>.+)"" (?<target_id>\d+) (?<numevals>\d+)")]
+    [UsageText("eval <castable> <target id> <number of evals>")]
+    public static CommandResult EvalDamage(User user, Match match)
+    {
+        if (!int.TryParse(match.Groups["numevals"].Value, out var numEvals))
+            return Fail("couldn't parse number of rolls");
+        if (!uint.TryParse(match.Groups["target_id"].Value, out var target_id))
+            return Fail("couldn't parse number of rolls");
+
+        if (!Game.World.WorldData.TryGetValueByIndex(match.Groups["castable"].Value, out Castable castable))
+            return Fail("Sorry, I couldn't find that castable.");
+        if (!Game.World.Objects.TryGetValue(target_id, out WorldObject wobj))
+            return Fail($"Sorry, I couldn't find object {match.Groups[1].Value}");
+        if (wobj is not Creature creatureObj)
+            return Fail("Sorry, that isn't a creature.");
+
+        var damages = new List<DamageOutput>();
+        for (var x = 0; x < Convert.ToUInt32(match.Groups["numevals"].Value); x++)
+        {
+            var output = NumberCruncher.CalculateDamage(castable, creatureObj, user);
+            damages.Add(output);
+        }
+
+        // Only use "slate" if more than one calculation
+        if (damages.Count == 1)
+            return Success($"Result: {damages[0].Amount} ({damages[0].Element}, {damages[0].Type})");
+
+        var ret = string.Empty;
+        damages.ForEach(x => ret += $"{x.Amount} ({x.Element}, {x.Type})\n");
+        var avg = damages.Select(x => x.Amount).Average();
+        return Success($"Runs: {damages.Count}    Average: {avg}\n\n{ret}", MessageType.SlateScrollbar);
+    }
+}

--- a/hybrasyl/ChatCommands/Stats.cs
+++ b/hybrasyl/ChatCommands/Stats.cs
@@ -178,6 +178,29 @@ class DamageCommand : ChatCommand
     }
 }
 
+class DamageInvCommand : ChatCommand
+{
+    public new static string Command = "damageinv";
+    public new static string ArgumentText = "";
+    public new static string HelpText = "Damage the items in your inventory (useful for testing repair)";
+    public new static bool Privileged = true;
+
+    public new static ChatCommandResult Run(User user, params string[] args)
+    {
+        var dura = string.Empty;
+        foreach (var item in user.Inventory)
+        {
+            if (item.Durability != 0)
+            {
+                item.Durability /= 2;
+                dura += $"{item.Name} -> {item.Durability} / {item.MaximumDurability}\n";
+            }
+        }
+        user.SendInventory();
+
+        return Success(dura, (byte) MessageType.SlateScrollbar);
+    }
+}
 class ExpCommand : ChatCommand
 {
     public new static string Command = "exp";

--- a/hybrasyl/Controllers/MerchantController.cs
+++ b/hybrasyl/Controllers/MerchantController.cs
@@ -1,0 +1,424 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Xml;
+using Hybrasyl.ChatCommands;
+using Hybrasyl.Enums;
+using Hybrasyl.Objects;
+using Hybrasyl.Xml;
+
+namespace Hybrasyl.Controllers
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class MerchantRequiredJob : Attribute
+    {
+        public MerchantJob Job { get; set; }
+
+        public MerchantRequiredJob(MerchantJob job)
+        {
+            Job = job;
+        }
+    }
+
+    public record MerchantControllerRequest(VisibleObject Speaker, GroupCollection Match);
+    public record MerchantCommand(Action<MerchantControllerRequest> Action, MerchantJob RequiredJob);
+
+    public class MerchantController
+    {
+
+        private readonly Merchant Merchant;
+
+        // TODO: static?
+        private Dictionary<Regex, MerchantCommand> Triggers = new();
+
+        public static string Pluralize(uint amount)
+        {
+            return amount switch
+            {
+                0 => "no coins",
+                1 => "1 coin",
+                > 1 => $"{amount} coins"
+            };
+        }
+
+        public static string Verb(uint amount) => amount == 1 ? "is" : "are";
+
+        public MerchantController(Merchant merchant)
+        {
+            Merchant = merchant;
+            foreach (var method in typeof(MerchantController).GetMethods())
+            {
+                var attr = method.GetCustomAttribute<RegexTrigger>();
+                if (attr == null) continue;
+                var regex = new Regex(attr.Trigger, RegexOptions.IgnoreCase);
+                var job = MerchantJob.None;
+                var action = (Action<MerchantControllerRequest>) Delegate.CreateDelegate(
+                    typeof(Action<MerchantControllerRequest>), this, method, false);
+                var jobAttr = method.GetCustomAttribute<MerchantRequiredJob>();
+                if (jobAttr != null)
+                    job = jobAttr.Job;
+                Triggers.Add(regex, new MerchantCommand(action, job));
+            }
+        }
+
+
+        public bool Evaluate(VisibleObject speaker, string input, bool shout = false)
+        {
+            foreach (var (key, value) in Triggers)
+            {
+                var match = key.Match(input);
+                if (!match.Success) continue;
+                if (value.RequiredJob != MerchantJob.None && !Merchant.Jobs.HasFlag(value.RequiredJob))
+                {
+                    Merchant.Say("Sorry, I can't do that.");
+                    return true;
+                }
+                value.Action(new MerchantControllerRequest(speaker, match.Groups));
+                return true;
+            }
+            return false;
+        }
+
+        [RegexTrigger(@"how many (?<item>.*) do i have (deposited|on deposit)")]
+        [MerchantRequiredJob(MerchantJob.Bank)]
+        public void QuantityDeposited(MerchantControllerRequest request)
+        {
+            if (request.Speaker is not User user) return;
+
+            if (user.Vault.Items.TryGetValue(request.Match["item"].Value, out var qty))
+            {
+                Merchant.Say($"You have {qty} of those deposited.");
+                return;
+            }
+            Merchant.Say("You have none of those deposited.");
+        }
+
+        [RegexTrigger(@"how much gold do i have (deposited|on deposit)")]
+        [MerchantRequiredJob(MerchantJob.Bank)]
+        public void GoldOnDeposit(MerchantControllerRequest request)
+        {
+            if (request.Speaker is not User user) return;
+            Merchant.Say($"You have {Pluralize(user.Vault.CurrentGold)} on deposit.");
+        }
+
+        [RegexTrigger(@"buy\\s+(?<amt>\\d+|all)\\s+of\\s+my\\s+(?<target>.*)")]
+        [MerchantRequiredJob(MerchantJob.Vend)]
+        public void Buy(MerchantControllerRequest request)
+        {
+            if (request.Speaker is not User user) return;
+
+            var items = Game.World.WorldData.FindItem(request.Match["target"].Value);
+            // Is the thing a category or an actual item?
+            if (items.Count != 0)
+            {
+                // Support both "buy 3 of my <item> and buy all of my <item>
+                if (request.Match["amt"].Value.ToLower() == "all")
+                {
+                    uint coins = 0;
+                    var removed = 0;
+                    foreach (var slot in user.Inventory.GetSlotsByName(request.Match["target"].Value))
+                    {
+                        coins += (uint)(user.Inventory[slot].Value * user.Inventory[slot].Count);
+                        removed += user.Inventory[slot].Count;
+                        user.RemoveItem(slot);
+                    }
+
+                    if (removed > 0)
+                    {
+                        Merchant.Say($"Certainly. I will buy {removed} of those for {coins} gold, {user.Name}.");
+                        user.Stats.Gold += coins;
+                        user.UpdateAttributes(StatUpdateFlags.Experience);
+                    }
+                    else
+                        user.SendSystemMessage($"\"Sorry, {user.Name},\" {Merchant.Name} says. \"You don't have those!\"");
+                }
+                else if (int.TryParse(request.Match["amt"].Value, out var qty))
+                {
+                    if (user.Inventory.ContainsName(request.Match["target"].Value, qty))
+                    {
+                        // Deal with annoying duplicate name / different gender edge cases
+                        var actuallyRemoved = new List<(byte Slot, int Quantity)>();
+                        uint coins = 0;
+                        foreach (var item in items)
+                        {
+                            user.Inventory.TryRemoveQuantity(item.Id, out var removed, qty);
+                            actuallyRemoved.AddRange(removed);
+                            coins += (uint)(removed.Sum(x => x.Quantity) * item.Properties.Physical.Value);
+                        }
+
+                        if (actuallyRemoved.Count > 0)
+                        {
+                            foreach (var (slot, _) in actuallyRemoved)
+                            {
+                                if (user.Inventory[slot] == null)
+                                    user.SendClearItem(slot);
+                                else
+                                    user.SendItemUpdate(user.Inventory[slot], slot);
+                            }
+                            Merchant.Say($"Certainly. I will buy {actuallyRemoved.Sum(x => x.Quantity)} of those for {coins} gold, {user.Name}.");
+                            user.Stats.Gold += coins;
+                            user.UpdateAttributes(StatUpdateFlags.Experience);
+                        }
+                        else
+                            user.SendSystemMessage($"\"Sorry, {user.Name},\" {Merchant.Name} says. \"You don't have those!\"");
+                    }
+                    else
+                        user.SendSystemMessage($"\"Sorry, {user.Name},\" {Merchant.Name} says. \"You don't have those!\"");
+                }
+            }
+            else if (Game.World.WorldData.ItemByCategory.ContainsKey(request.Match["target"].Value))
+            {
+                uint coins = 0;
+                // Only support "buy all my <category>"
+                foreach (var slot in user.Inventory.GetSlotsByCategory(request.Match["target"].Value))
+                {
+                    coins += (uint)(user.Inventory[slot].Value * user.Inventory[slot].Count);
+                    user.RemoveItem(slot);
+                }
+                Merchant.Say($"Certainly. That will be {coins} gold, {user.Name}.");
+                user.Stats.Gold += coins;
+                user.UpdateAttributes(StatUpdateFlags.Experience);
+            }
+            else
+                user.SendSystemMessage($"{Merchant.Name} shrugs. \"Sorry, I don't know what you mean.\"");
+        }
+
+
+        [RegexTrigger(@"repair (all|everything|all my items)")]
+        [MerchantRequiredJob(MerchantJob.Repair)]
+        public void RepairAll(MerchantControllerRequest request)
+        {
+            if (request.Speaker is not User user) return;
+            var repairTotal = 0;
+            foreach (var item in user.Inventory)
+            {
+                if (item.MaximumDurability == 0 || item.Durability == item.MaximumDurability) continue;
+                if (item.RepairCost > user.Stats.Gold)
+                {
+                    Merchant.Say("You'll need more gold to repair all of it, I'm afraid");
+                    return;
+                }
+
+                item.Durability = item.MaximumDurability;
+                user.Stats.Gold -= item.RepairCost;
+                repairTotal += (int) item.RepairCost;
+            }
+            foreach (var item in user.Equipment)
+            {
+                if (item.MaximumDurability == 0 || item.Durability == item.MaximumDurability) continue;
+                if (item.RepairCost > user.Stats.Gold)
+                {
+                    Merchant.Say("You'll need more gold to repair all of it, I'm afraid");
+                    return;
+                }
+
+                item.Durability = item.MaximumDurability;
+                user.Stats.Gold -= item.RepairCost;
+                repairTotal += (int)item.RepairCost;
+            }
+            if (repairTotal > 0)
+            {
+                Merchant.Say($"I repaired it all for {repairTotal} coins.");
+                user.SendInventory();
+                user.SendEquipment();
+                user.UpdateAttributes(StatUpdateFlags.Full);
+                return;
+            }
+            Merchant.Say("Nothing needed to be repaired.");
+
+        }
+
+        [RegexTrigger(@"repair (?<item>.*)")]
+        [MerchantRequiredJob(MerchantJob.Repair)]
+        public void RepairItem(MerchantControllerRequest request)
+        {
+            if (request.Speaker is not User user) return;
+            List<(byte slot, ItemObject obj)> slotList;
+            if (!user.Inventory.TryGetValueByName(request.Match["item"].Value, out slotList) &&
+                !user.Equipment.TryGetValueByName(request.Match["item"].Value, out slotList))
+            {
+                Merchant.Say("You don't seem to have one of those.");
+                return;
+            }
+
+            foreach (var (slot, obj) in slotList)
+            {
+                if (obj.MaximumDurability == 0 || obj.Durability == obj.MaximumDurability) continue;
+                if (obj.RepairCost > user.Stats.Gold)
+                {
+                    Merchant.Say("You'll need more gold to repair that, I'm afraid");
+                    return;
+                }
+
+                obj.Durability = obj.MaximumDurability;
+                user.Stats.Gold -= obj.RepairCost;
+                user.SendInventorySlot(slot);
+            }
+        }
+
+        [RegexTrigger(@"deposit (?<amount>\d+) (coins|gold|coin)")]
+        [MerchantRequiredJob(MerchantJob.Bank)]
+        public void DepositGold(MerchantControllerRequest request)
+        {
+            if (request.Speaker is not User user) return;
+
+            if (!uint.TryParse(request.Match["amount"].Value, out var gold))
+            {
+                Merchant.Say("I don't know what you mean.");
+                return;
+            }
+
+            if (gold > user.Stats.Gold)
+            {
+                Merchant.Say("You don't have that much.");
+                return;
+            }
+
+            if (user.Vault.AddGold(gold))
+            {
+                Merchant.Say($"I'll take your {Pluralize(gold)}");
+                user.Stats.Gold -= gold;
+                user.UpdateAttributes(StatUpdateFlags.Experience);
+                return;
+            }
+
+            Merchant.Say("Sorry, you can't deposit any more gold.");
+
+        }
+
+        [RegexTrigger(@"deposit (?<item>.*)")]
+        [MerchantRequiredJob(MerchantJob.Bank)]
+        public void DepositItem(MerchantControllerRequest request)
+        {
+            if (request.Speaker is not User user) return;
+            List<(byte slot, ItemObject obj)> slot;
+            if (!user.Inventory.TryGetValueByName(request.Match["item"].Value, out slot))
+            {
+                Merchant.Say("You don't seem to have one of those.");
+                return;
+            }
+
+            // Even if multiple results are returned, use the first one
+            var first = slot.First();
+            var fee = (uint) Math.Round(first.obj.Value * 0.10, 0);
+
+            // TODO: HS-1257
+            if (!first.obj.Depositable)
+            {
+                Merchant.Say("No. I don't even want to touch it.");
+                return;
+            }
+
+            if (first.obj.Durability != 0 && first.obj.Durability != first.obj.MaximumDurability)
+            {
+                Merchant.Say("I don't want your junk. Ask a smith to fix it.");
+                return;
+            }
+
+            if (fee > user.Stats.Gold)
+            {
+                Merchant.Say($"I'll need {Pluralize(fee)} coins to deposit that.");
+                return;
+            }
+
+            if (user.Vault.IsFull)
+            {
+                Merchant.Say("I can't take any more of your items.");
+                return;
+            }
+
+            if (user.Inventory[first.slot].Stackable && user.Inventory[first.slot].Count > 1)
+            {
+                user.RemoveItem(first.obj.Name, 1);
+            }
+            else
+            {
+                user.RemoveItem(first.slot);
+            }
+
+            user.RemoveGold(fee);
+            Game.World.Remove(first.obj);
+            user.Vault.AddItem(first.obj.Name);
+            user.Vault.Save();
+            Merchant.Say($"{first.obj.Name}, that'll be {fee} coins.");
+        }
+
+        [RegexTrigger(@"withdraw (?<amt>\d+) (coins|gold|coin)")]
+        [MerchantRequiredJob(MerchantJob.Bank)]
+        public void WithdrawGold(MerchantControllerRequest request)
+        {
+            if (request.Speaker is not User user) return;
+            if (!uint.TryParse(request.Match["amt"].Value, out var gold))
+            {
+                Merchant.Say("I don't know what you mean.");
+                return;
+            }
+
+            if (!user.Vault.RemoveGold(gold))
+            {
+                Merchant.Say("Sorry, you don't have that much on deposit.");
+                return;
+            }
+            user.Stats.Gold += gold;
+            user.Vault.RemoveGold(gold);
+            user.UpdateAttributes(StatUpdateFlags.Experience);
+            Merchant.Say($"Here {Verb(gold)} your {Pluralize(gold)}.");
+        }
+
+        [RegexTrigger(@"withdraw (?<item>.*)")]
+        [MerchantRequiredJob(MerchantJob.Bank)]
+        public void WithdrawItem(MerchantControllerRequest request)
+        {
+            if (request.Speaker is not User user) return;
+
+            if (!user.Vault.Items.ContainsKey(request.Match["item"].Value))
+            {
+                Merchant.Say("You don't have any of those.");
+                return;
+            }
+
+            if (!Game.World.WorldData.TryGetValueByIndex(request.Match["item"].Value, out Item item))
+            {
+                Merchant.Say("I don't know what that is.");
+                return;
+            }
+
+            var match = user.Inventory.GetSlotsByName(request.Match["item"].Value);
+            if (!match.Any() && user.Inventory.IsFull)
+            {
+                Merchant.Say("Sorry, you can't hold any more of those.");
+                return;
+            }
+
+            foreach (var slot in match)
+            {
+                if (user.Inventory[slot].Stackable && user.Inventory[slot].Count != user.Inventory[slot].MaximumStack)
+                {
+                    user.Inventory[slot].Count++;
+                    user.SendInventorySlot(slot);
+                    Merchant.Say($"Here's your {user.Inventory[slot].Name} back.");
+                    return;
+                }
+            }
+
+            if (user.Inventory.IsFull)
+            {
+                Merchant.Say("Sorry, you can't hold any more of those.");
+                return;
+            }
+
+            user.Vault.RemoveItem(item.Name);
+            var itemObj = new ItemObject(item, user.World.Guid);
+            itemObj.Durability = itemObj.MaximumDurability;
+            var newSlot = user.Inventory.FindEmptySlot();
+            user.Inventory[newSlot] = itemObj;
+            user.SendInventorySlot(newSlot);
+            Merchant.Say($"Here's your {itemObj.Name} back.");
+        }
+
+    }
+}

--- a/hybrasyl/Controllers/MerchantController.cs
+++ b/hybrasyl/Controllers/MerchantController.cs
@@ -189,7 +189,7 @@ namespace Hybrasyl.Controllers
         }
 
 
-        [RegexTrigger(@"repair (all|everything|all my items)")]
+        [RegexTrigger(@"repair all")]
         [MerchantRequiredJob(MerchantJob.Repair)]
         public void RepairAll(MerchantControllerRequest request)
         {
@@ -200,7 +200,7 @@ namespace Hybrasyl.Controllers
                 if (item.MaximumDurability == 0 || item.Durability == item.MaximumDurability) continue;
                 if (item.RepairCost > user.Stats.Gold)
                 {
-                    Merchant.Say("You'll need more gold to repair all of it, I'm afraid");
+                    Merchant.Say($"You'll need {item.RepairCost} more gold to repair all of it, I'm afraid.");
                     return;
                 }
 
@@ -213,7 +213,7 @@ namespace Hybrasyl.Controllers
                 if (item.MaximumDurability == 0 || item.Durability == item.MaximumDurability) continue;
                 if (item.RepairCost > user.Stats.Gold)
                 {
-                    Merchant.Say("You'll need more gold to repair all of it, I'm afraid");
+                    Merchant.Say($"You'll need {item.RepairCost} more gold to repair all of it, I'm afraid.");
                     return;
                 }
 
@@ -233,7 +233,7 @@ namespace Hybrasyl.Controllers
 
         }
 
-        [RegexTrigger(@"repair (?<item>.*)")]
+        [RegexTrigger(@"repair my (?<item>.*)")]
         [MerchantRequiredJob(MerchantJob.Repair)]
         public void RepairItem(MerchantControllerRequest request)
         {
@@ -251,9 +251,10 @@ namespace Hybrasyl.Controllers
                 if (obj.MaximumDurability == 0 || obj.Durability == obj.MaximumDurability) continue;
                 if (obj.RepairCost > user.Stats.Gold)
                 {
-                    Merchant.Say("You'll need more gold to repair that, I'm afraid");
+                    Merchant.Say($"You'll need {obj.RepairCost} more gold to repair that, I'm afraid.");
                     return;
                 }
+                Merchant.Say($"I repaired your {obj.Name} for {obj.RepairCost} coins.");
 
                 obj.Durability = obj.MaximumDurability;
                 user.Stats.Gold -= obj.RepairCost;

--- a/hybrasyl/Hybrasyl.csproj
+++ b/hybrasyl/Hybrasyl.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/hybrasyl/server</RepositoryUrl>
     <Company>Project Hybrasyl</Company>
     <Product>Hybrasyl Server</Product>
-    <VersionPrefix>0.9.0</VersionPrefix>
+    <VersionPrefix>0.9.1</VersionPrefix>
     <Description>Hybrasyl, a DOOMVAS v1 emulator</Description>
     <BuildDocFx Condition="'$(Configuration)'=='Debug' ">false</BuildDocFx>
   </PropertyGroup>

--- a/hybrasyl/Hybrasyl.csproj
+++ b/hybrasyl/Hybrasyl.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/hybrasyl/server</RepositoryUrl>
     <Company>Project Hybrasyl</Company>
     <Product>Hybrasyl Server</Product>
-    <VersionPrefix>0.8.0</VersionPrefix>
+    <VersionPrefix>0.9.0</VersionPrefix>
     <Description>Hybrasyl, a DOOMVAS v1 emulator</Description>
     <BuildDocFx Condition="'$(Configuration)'=='Debug' ">false</BuildDocFx>
   </PropertyGroup>

--- a/hybrasyl/Inventory.cs
+++ b/hybrasyl/Inventory.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Hybrasyl.ChatCommands;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Hybrasyl.Threading;
@@ -379,6 +380,12 @@ public class Vault
     public Dictionary<string, uint> Items { get; private set; } //item name, quantity
 
     public Vault() { }
+
+    public void Clear()
+    {
+        CurrentGold = 0;
+        Items = new Dictionary<string, uint>(StringComparer.OrdinalIgnoreCase);
+    }
 
     public Vault(Guid ownerGuid)
     {

--- a/hybrasyl/Inventory.cs
+++ b/hybrasyl/Inventory.cs
@@ -371,6 +371,7 @@ public class Vault
     public uint RemainingGold => GoldLimit - CurrentGold;
     public ushort RemainingItems => (ushort)(ItemLimit - CurrentItemCount);
     public bool IsSaving;
+    public bool IsFull => CurrentItemCount == ItemLimit;
 
     public string StorageKey => string.Concat(GetType(), ':', OwnerGuid);
 
@@ -384,7 +385,7 @@ public class Vault
         GoldLimit = uint.MaxValue;
         ItemLimit = ushort.MaxValue;
         CurrentGold = 0;
-        Items = new Dictionary<string, uint>();
+        Items = new Dictionary<string, uint>(StringComparer.OrdinalIgnoreCase);
         OwnerGuid = ownerGuid;
     }
 

--- a/hybrasyl/Inventory.cs
+++ b/hybrasyl/Inventory.cs
@@ -112,6 +112,10 @@ public class Exchange
             return false;
         }
 
+        // Have they already confirmed?
+        if (_sourceConfirmed || _targetConfirmed)
+            return false;
+
         // OK - we have room, now what?
         var theItem = giver.Inventory[slot];
 

--- a/hybrasyl/LootBox.cs
+++ b/hybrasyl/LootBox.cs
@@ -243,10 +243,6 @@ public static class LootBox
             loot.Add(item);
         }
         var totalRolls = 0;
-        var onlyMaxUnique = list.Item.Count(i => !i.Unique) == list.Item.Count;
-        var onlyMaxDrop = list.Item.Count(i => i.Max > 0) == list.Item.Count;
-        var sumUnique = list.Item.Where(i => i.Unique).Count();
-        var sumMax = list.Item.Select(i => i.Max > 0).Count();
 
         // Process the rest of the rolls now
         do
@@ -256,41 +252,21 @@ public static class LootBox
             // As soon as we get an item from our table, we've "rolled"; we'll add another roll below if needed
             rolls--;
             totalRolls++;
-            // Check uniqueness. If something has already dropped, don't drop it again, and reroll
+            // As a check against something incredibly stupid in XML, we only allow a maximum of
+            // 100 rolls
+            if (totalRolls > 100)
+                throw new LootRecursionError("Maximum number of rolls (100) exceeded!");
+            // Check uniqueness. 
 
             if (item.Unique && loot.Contains(item))
-            {
-                rolls++;
-                if (rolls >= sumUnique && onlyMaxUnique)
-                {
-                    GameLog.SpawnError("Rolling abandoned due to unresolvable rolls (rolls > unique)");
-                    break;
-                }
-
                 continue;
-            }
 
-            // Check max quantity. If it is exceeded, reroll
-
+            // Check max quantity.
             if (item.Max > 0 && loot.Count(i => i.Value == item.Value) >= item.Max)
-            {
-                rolls++;
-                if (rolls >= sumMax && onlyMaxDrop)
-                {
-                    GameLog.SpawnError("Rolling abandoned due to unresolvable rolls (rolls > unique)");
-                    break;
-                }
-
                 continue;
-            }
 
             // If quantity and uniqueness are good, add the item
             loot.Add(item);
-            // As a check against something incredibly stupid in XML, we only allow a maximum of
-            // 100 rolls
-            if (totalRolls <= 100) continue;
-            GameLog.SpawnError("Processing loot: added duplicate unique item {item}. Rerolling", item.Value);
-            throw new LootRecursionError("Maximum number of rolls (100) exceeded!");
         }
         while (rolls > 0);
 
@@ -308,6 +284,7 @@ public static class LootBox
                 // If multiple variants are specified, we pick one at random
                 if (lootitem.Variants.Any())
                 {
+                    // Determine overlap between available variants and specified variants
                     var lootedVariant = lootitem.Variants.PickRandom();
                     if (xmlItem.Variants.TryGetValue(lootedVariant, out List<Item> variantItems))
                         itemList.Add(Game.World.CreateItem(variantItems.PickRandom().Id));

--- a/hybrasyl/LootBox.cs
+++ b/hybrasyl/LootBox.cs
@@ -260,9 +260,13 @@ public static class LootBox
 
             if (item.Unique && loot.Contains(item))
             {
-                if (rolls >= sumUnique && onlyMaxUnique)
-                    continue;
                 rolls++;
+                if (rolls >= sumUnique && onlyMaxUnique)
+                {
+                    GameLog.SpawnError("Rolling abandoned due to unresolvable rolls (rolls > unique)");
+                    break;
+                }
+
                 continue;
             }
 
@@ -270,9 +274,13 @@ public static class LootBox
 
             if (item.Max > 0 && loot.Count(i => i.Value == item.Value) >= item.Max)
             {
-                if (rolls >= sumMax && onlyMaxDrop)
-                    continue;
                 rolls++;
+                if (rolls >= sumMax && onlyMaxDrop)
+                {
+                    GameLog.SpawnError("Rolling abandoned due to unresolvable rolls (rolls > unique)");
+                    break;
+                }
+
                 continue;
             }
 

--- a/hybrasyl/LootBox.cs
+++ b/hybrasyl/LootBox.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Hybrasyl.Xml;
 
 namespace Hybrasyl;
 
@@ -32,15 +33,12 @@ public class Loot
     {
         Xp = xp;
         Gold = gold;
-        if (items == null)
-            Items = new List<string>();
-        else
-            Items = items;
+        Items = items ?? new List<string>();
     }
 
     public static Loot operator +(Loot a) => a;
 
-    public static Loot operator +(Loot a, Xml.Item b)
+    public static Loot operator +(Loot a, Item b)
     {
         var ret = new Loot(a.Xp, a.Gold);
         ret.Items.AddRange(a.Items);
@@ -49,6 +47,11 @@ public class Loot
     }
 
     public static Loot operator +(Loot a, Loot b) => new Loot(a.Xp + b.Xp, a.Gold + b.Gold, a.Items.Concat(b.Items).ToList());
+
+    public override string ToString()
+    {
+        return $"XP: {Xp}\nGold: {Gold}\nItems: " + string.Join(",", Items);
+    }
 }
 
 /// <summary>
@@ -89,111 +92,100 @@ public static class LootBox
     /// <returns></returns>
     public static uint RollBetween(uint a, uint b) => (uint) Random.Shared.Next((int) a, (int) b + 1);
 
-    /// <summary>
-    /// Calculate loot for a given spawn.
-    /// </summary>
-    /// <param name="spawn">The spawn we will use to calculate Loot.</param>
-    /// <returns>A Loot struct with XP, gold and items, if any</returns>
-    public static Loot CalculateLoot(Xml.Spawn spawn)
+    public static Loot CalculateLoot(LootSet set, int rolls, float chance)
     {
-
-        // Loot calculations are not particularly complex but have a lot of components:
-        // Spawns can have loot sets, loot tables, or both.
-        // We resolve sets first, then tables. We keep a running tab of gold drops.
-        // Lastly, we return a Loot struct with our calculations.
-
-        var loot = new Loot(0, 0);
-        var tables = new List<Xml.LootTable>();
-        if (spawn.Loot is null) 
-            // Can't do anything if nothing is defined
-            return loot;
-        // Assign base XP
-        loot.Xp = spawn.Loot.Xp;
-        // Sets
-        foreach (var set in spawn.Loot?.Set ?? new List<Xml.LootImport>())
+        var loot = new Loot(0,0);
+        var tables = new List<LootTable>();
+ 
+        // If rolls == 0, all tables fire
+        if (rolls == 0)
         {
-            // Is the set present?
-            GameLog.SpawnInfo("Processing loot set {Name}", set.Name);
-            if (Game.World.WorldData.TryGetValueByIndex(set.Name, out Xml.LootSet lootset))
+            tables.AddRange(set.Table);
+            GameLog.SpawnInfo("Processing loot set {Name}: set rolls == 0, looting", set.Name);
+        }
+
+        for (var x = 0; x < rolls; x++)
+        {
+            if (Roll() <= chance)
             {
-                // Set is present, does it fire?
-                // Chance is implemented as a decimalized percentage, e.g. 0.08 = 8% chance
+                GameLog.SpawnInfo("Processing loot set {Name}: set hit, looting", set.Name);
 
-                // If rolls == 0, all tables fire
-                if (set.Rolls == 0)
+                // Ok, the set fired. Check the subtables, which can have independent chances.
+                // If no chance is present, we simply award something from each table in the set.
+                // Note that we do table processing last! We just find the tables that fire here.
+                foreach (var setTable in set.Table)
                 {
-                    tables.AddRange(lootset.Table);
-                    GameLog.SpawnInfo("Processing loot set {Name}: set rolls == 0, looting", set.Name);
-                    continue;
-                }
-
-                for (var x = 0; x < set.Rolls; x++)
-                {
-                    if (Roll() <= set.Chance)
+                    // Rolls == 0 (default) means the table is automatically used.
+                    if (setTable.Rolls == 0)
                     {
-                        GameLog.SpawnInfo("Processing loot set {Name}: set hit, looting", set.Name);
-
-                        // Ok, the set fired. Check the subtables, which can have independent chances.
-                        // If no chance is present, we simply award something from each table in the set.
-                        // Note that we do table processing last! We just find the tables that fire here.
-                        foreach (var setTable in lootset.Table)
-                        {
-                            // Rolls == 0 (default) means the table is automatically used.
-                            if (setTable.Rolls == 0)
-                            {
-                                tables.Add(setTable);
-                                GameLog.SpawnInfo("Processing loot set {Name}: setTable rolls == 0, looting", set.Name);
-                                continue;
-                            }
-                            // Did the subtable hit?
-                            for (var y = 0; y < setTable.Rolls; y++)
-                            {
-                                if (Roll() <= setTable.Chance)
-                                {
-                                    tables.Add(setTable);
-                                    GameLog.SpawnInfo("Processing loot set {Name}: set subtable hit, looting ", set.Name);
-                                }
-                            }
-                        }
+                        tables.Add(setTable);
+                        GameLog.SpawnInfo("Processing loot set {Name}: setTable rolls == 0, looting", set.Name);
+                        continue;
                     }
-                    else
-                        GameLog.SpawnInfo("Processing loot set {Name}: Set subtable missed", set.Name);
+
+                    // Did the subtable hit?
+                    for (var y = 0; y < setTable.Rolls; y++)
+                    {
+                        if (!(Roll() <= setTable.Chance)) continue;
+                        tables.Add(setTable);
+                        GameLog.SpawnInfo("Processing loot set {Name}: set subtable hit, looting ", set.Name);
+                    }
                 }
             }
             else
-                GameLog.Warning("Spawn {name}: Loot set {name} missing", spawn.Base, set.Name);
+                GameLog.SpawnInfo("Processing loot set {Name}: Set subtable missed", set.Name);
+        }
+
+        return tables.Aggregate(loot, (current, table) => current + CalculateTable(table));
+
+    }
+
+    /// <summary>
+    /// Calculate loot for a given loot list (can be defined at spawngroup / creature / spawn level)
+    /// </summary>
+    /// <param name="list"></param>
+    /// <returns></returns>
+    public static Loot CalculateLoot(LootList list)
+    {
+        var loot = new Loot(0, 0);
+        var tables = new List<LootTable>();
+        if (list == null || list.IsEmpty) return loot;
+
+        foreach (var set in list.Set ?? new List<LootImport>())
+        {
+            // Is the set present?
+            GameLog.SpawnInfo("Processing loot set {Name}", set.Name);
+            if (Game.World.WorldData.TryGetValueByIndex(set.Name, out LootSet lootset))
+            {
+                loot += CalculateLoot(lootset, set.Rolls, set.Chance);
+            }
+            else
+                GameLog.Warning("Loot set {name} referenced in list, but could not be loaded",  set.Name);
+
         }
 
         // Now, calculate loot for any tables attached to the spawn
-        foreach (var table in spawn.Loot?.Table ?? new List<Xml.LootTable>())
+        foreach (var table in list.Table)
         {
             if (table.Rolls == 0)
             {
                 tables.Add(table);
-                GameLog.SpawnInfo("Processing loot: spawn table for {Name}, rolls == 0, looting", spawn.Base);
                 continue;
             }
             for (var z = 0; z <= table.Rolls; z++)
             {
                 if (Roll() <= table.Chance)
-                {
-                    GameLog.SpawnInfo("Processing loot: spawn table for {Name} hit, looting", spawn.Base);
                     tables.Add(table);
-                }
-                else
-                    GameLog.SpawnInfo("Processing loot set {Name}: Spawn subtable missed", spawn.Base);
-
             }
         }
 
         // Now that we have all tables that fired, we need to calculate actual loot
 
-        GameLog.SpawnInfo("Loot for {Name}: tables: {Count}", spawn.Base, tables.Count());
         foreach (var table in tables)
             loot += CalculateTable(table);
 
-        GameLog.SpawnInfo("Final loot for {Name}: {Xp} xp, {Gold} gold, items [{items}]", spawn.Base, loot.Xp, loot.Gold, string.Join(",", loot.Items));
         return loot;
+
     }
 
     /// <summary>
@@ -201,7 +193,7 @@ public static class LootBox
     /// </summary>
     /// <param name="table">The table to be evaluated.</param>
     /// <returns>Loot structure containing Xp/Gold/List of items to be awarded.</returns>
-    public static Loot CalculateTable(Xml.LootTable table)
+    public static Loot CalculateTable(LootTable table)
     {
         var tableLoot = new Loot(0, 0);
         if (table.Gold != null)
@@ -236,11 +228,11 @@ public static class LootBox
     /// </summary>
     /// <param name="list">LootTableItemList containing items</param>
     /// <returns>List of items</returns>
-    public static List<string> CalculateItems(Xml.LootTableItemList list)
+    public static List<string> CalculateItems(LootTableItemList list)
     {
         // Ordinarily, return one item from the list.
         var rolls = CalculateSuccessfulRolls(list.Rolls, list.Chance);
-        var loot = new List<Xml.LootItem>();
+        var loot = new List<LootItem>();
         var itemList = new List<ItemObject>();
 
         // First, process any "always" items, which always drop when the container fires
@@ -280,11 +272,9 @@ public static class LootBox
             totalRolls++;
             // As a check against something incredibly stupid in XML, we only allow a maximum of
             // 100 rolls
-            if (totalRolls > 100)
-            {
-                GameLog.SpawnInfo("Processing loot: maximum number of rolls exceeded..?");
-                throw new LootRecursionError("Maximum number of rolls (100) exceeded!");
-            }
+            if (totalRolls <= 100) continue;
+            GameLog.SpawnInfo("Processing loot: maximum number of rolls exceeded..?");
+            throw new LootRecursionError("Maximum number of rolls (100) exceeded!");
         }
         while (rolls > 0);
 
@@ -300,10 +290,10 @@ public static class LootBox
                 var xmlItem = xmlItemList.First();
                 // Handle variants.
                 // If multiple variants are specified, we pick one at random
-                if (lootitem.Variants.Count() > 0)
+                if (lootitem.Variants.Any())
                 {
                     var lootedVariant = lootitem.Variants.PickRandom();
-                    if (xmlItem.Variants.TryGetValue(lootedVariant, out List<Xml.Item> variantItems))
+                    if (xmlItem.Variants.TryGetValue(lootedVariant, out List<Item> variantItems))
                         itemList.Add(Game.World.CreateItem(variantItems.PickRandom().Id));
                     else
                         GameLog.SpawnError("Spawn loot calculation: variant group {name} not found", lootedVariant);
@@ -317,8 +307,6 @@ public static class LootBox
         }
         // We store loot as strings inside mobs to avoid having tens or hundreds of thousands of ItemObjects or
         // Items lying around - they're made into real objects at the time of mob death
-        if (itemList.Count > 0)
-            return itemList.Where(x => x != null).Select(y => y.Name).ToList();
-        return new List<String>();
+        return itemList.Count > 0 ? itemList.Where(x => x != null).Select(y => y.Name).ToList() : new List<string>();
     }
 }

--- a/hybrasyl/Map.cs
+++ b/hybrasyl/Map.cs
@@ -184,6 +184,14 @@ public class Map
         }
     }
 
+    public List<Monster> Monsters
+    {
+        get
+        {
+            lock (_lock)
+                return Objects.OfType<Monster>().ToList();
+        }
+    }
     public Dictionary<string, User> Users { get; private set; }
 
     public Dictionary<(byte X, byte Y), Door> Doors { get; set; }

--- a/hybrasyl/Messaging/SpokenEvent.cs
+++ b/hybrasyl/Messaging/SpokenEvent.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Hybrasyl.Objects;
+
+namespace Hybrasyl.Messaging
+{
+    public record SpokenEvent(VisibleObject Speaker, string Message, string From = null, bool Shout = false)
+    {
+        public string SanitizedMessage => Message.ToLower().Trim();
+    }
+}

--- a/hybrasyl/Monolith.cs
+++ b/hybrasyl/Monolith.cs
@@ -298,7 +298,6 @@ internal class Monolith
                                         _ => spawn.Damage.Element
                                     };
 
-                                    baseMob.Stats.OffensiveElementOverride = spawn.Damage.Element;
                                     var item = new ItemObject(newTemplate);
                                     baseMob.Equipment.Insert((byte) ItemSlots.Weapon, item);
                                 }

--- a/hybrasyl/Monolith.cs
+++ b/hybrasyl/Monolith.cs
@@ -192,6 +192,7 @@ internal class Monolith
                 {
                     var newSpawnLoot = LootBox.CalculateLoot(spawn.Loot);
                     newSpawnLoot += LootBox.CalculateLoot(creature.Loot);
+                    newSpawnLoot += LootBox.CalculateLoot(spawnGroup.Loot);
 
                     var baseMob = new Monster(creature, spawn.Flags, (byte) baseLevel, 
                        newSpawnLoot);

--- a/hybrasyl/Monolith.cs
+++ b/hybrasyl/Monolith.cs
@@ -110,7 +110,7 @@ internal class Monolith
         foreach (var spawn in spawnGroup.Spawns)
         {
             GameLog.SpawnInfo($"Spawngroup {spawnGroup.Name}: processing");
-            var monsters = spawnmap.Objects.OfType<Monster>().ToList();
+            var monsters = spawnmap.Monsters;
 
             // If the map is disabled, or we don't have a spec for our spawning, or the individual spawn
             // previously had errors and was disabled - continue on
@@ -190,8 +190,8 @@ internal class Monolith
             {
                 if (Game.World.WorldData.TryGetValue(spawn.Name, out Xml.Creature creature))
                 {
-                    var newSpawnLoot = LootBox.CalculateLoot(spawn);
-
+                    var newSpawnLoot = LootBox.CalculateLoot(spawn.Loot);
+                    newSpawnLoot += LootBox.CalculateLoot(creature.Loot);
 
                     var baseMob = new Monster(creature, spawn.Flags, (byte) baseLevel, 
                        newSpawnLoot);

--- a/hybrasyl/Monolith.cs
+++ b/hybrasyl/Monolith.cs
@@ -87,12 +87,19 @@ internal class Monolith
 
         while (true)
         {
-            if (World.ControlMessageQueue.IsCompleted)
-                break;
-            foreach (var key in Spawns.Keys)
-                if (Spawns.TryGetValue(key, out Xml.SpawnGroup group))
-                    Spawn(group);
-            Thread.Sleep(5000);
+            try
+            {
+                if (World.ControlMessageQueue.IsCompleted)
+                    break;
+                foreach (var key in Spawns.Keys)
+                    if (Spawns.TryGetValue(key, out Xml.SpawnGroup group))
+                        Spawn(group);
+                Thread.Sleep(5000);
+            }
+            catch (Exception ex)
+            {
+                GameLog.SpawnFatal($"Unhandled exception {ex} in spawn thread");
+            }
         }
     }
 
@@ -109,7 +116,8 @@ internal class Monolith
                     
         foreach (var spawn in spawnGroup.Spawns)
         {
-            GameLog.SpawnInfo($"Spawngroup {spawnGroup.Name}: processing");
+            if (spawnmap.SpawnDebug)
+                GameLog.SpawnInfo($"Spawngroup {spawnGroup.Name}: {spawn.Name} processing");
             var monsters = spawnmap.Monsters;
 
             // If the map is disabled, or we don't have a spec for our spawning, or the individual spawn
@@ -221,12 +229,14 @@ internal class Monolith
                                 if (mobtype <= spawn.Base.WeakChance)
                                 {
                                     baseMob.ApplyModifier(modifier * -1);
-                                    GameLog.SpawnInfo($"Mob is weak: modifier {modifier}");
+                                    if (spawnmap.SpawnDebug)
+                                        GameLog.SpawnInfo($"Mob is weak: modifier {modifier}");
                                 }
                                 else
                                 {
                                     baseMob.ApplyModifier(modifier);
-                                    GameLog.SpawnInfo($"Mob is strong: modifier {modifier}");
+                                    if (spawnmap.SpawnDebug)
+                                        GameLog.SpawnInfo($"Mob is strong: modifier {modifier}");
                                 }
                             }
                             else
@@ -234,12 +244,14 @@ internal class Monolith
                                 if (mobtype <= spawn.Base.StrongChance)
                                 {
                                     baseMob.ApplyModifier(modifier);
-                                    GameLog.SpawnInfo($"Mob is strong: modifier {modifier}");
+                                    if (spawnmap.SpawnDebug)
+                                        GameLog.SpawnInfo($"Mob is strong: modifier {modifier}");
                                 }
                                 else
                                 {
                                     baseMob.ApplyModifier(modifier * -1);
-                                    GameLog.SpawnInfo($"Mob is weak: modifier {modifier}");
+                                    if (spawnmap.SpawnDebug)
+                                        GameLog.SpawnInfo($"Mob is weak: modifier {modifier}");
                                 }
                             }
                         }
@@ -360,8 +372,6 @@ internal class Monolith
         if (!World.ControlMessageQueue.IsCompleted)
         {
             World.ControlMessageQueue.Add(new HybrasylControlMessage(ControlOpcodes.MonolithSpawn, monster, map));
-            //Game.World.Maps[mapId].InsertCreature(monster);
-            //if (map.SpawnDebug)
         }
                                                
     }

--- a/hybrasyl/NumberCruncher.cs
+++ b/hybrasyl/NumberCruncher.cs
@@ -261,10 +261,10 @@ static class NumberCruncher
 
         var costs = castable.CastCosts.Where(e => e.Class.Contains(user.Class));
 
-        if (costs.Count() == 0)
+        if (!costs.Any())
             costs = castable.CastCosts.Where(e => e.Class.Count == 0);
 
-        if (costs.Count() == 0)
+        if (!costs.Any())
             return cost;
 
         var toEvaluate = costs.First();
@@ -275,8 +275,8 @@ static class NumberCruncher
         if (toEvaluate.Stat?.Mp != null)
             cost.Mp = (uint) _evalFormula(toEvaluate.Stat.Mp, castable, target, source);
 
-        if (toEvaluate.Gold > 0)
-            cost.Gold = toEvaluate.Gold;
+        if (toEvaluate.Gold != null)
+            cost.Gold = (uint) _evalFormula(toEvaluate.Gold, castable, target, source);
 
         if (toEvaluate.Items.Count > 0)
             cost.Items = toEvaluate.Items.Select(x => (x.Quantity, x.Value)).ToList();

--- a/hybrasyl/NumberCruncher.cs
+++ b/hybrasyl/NumberCruncher.cs
@@ -371,6 +371,7 @@ static class NumberCruncher
     public static StatInfo CalculateStatusModifiers(Castable castable, double intensity, StatModifiers effect,
         Creature source, Creature target=null)
     {
+        if (effect is null) return new StatInfo();
         var modifiers = new StatInfo
         {
             DeltaHp = Modify(_evalFormula(effect.CurrentHp, castable, target, source), intensity),

--- a/hybrasyl/Objects/ItemObject.cs
+++ b/hybrasyl/Objects/ItemObject.cs
@@ -249,6 +249,16 @@ public class ItemObject : VisibleObject
         ? uint.MaxValue
         : Convert.ToUInt32(Template.Properties.Physical.Durability);
 
+    public uint RepairCost
+    {
+        get
+        {
+            if (MaximumDurability != 0)
+                return Durability == 0 ? Value : (uint) ((Durability / MaximumDurability) * Value);
+            return 0;
+        }
+    } 
+
     // For future use / expansion re: unidentified items.
     // Should pull from template and only allow false to be set when
     // Identifiable flag is set.
@@ -283,6 +293,7 @@ public class ItemObject : VisibleObject
 
 
     public bool Enchantable => Template.Properties.Flags.HasFlag(Xml.ItemFlags.Enchantable);
+    public bool Depositable => Template.Properties.Flags.HasFlag(ItemFlags.Depositable);
 
     public bool Consecratable => Template.Properties.Flags.HasFlag(Xml.ItemFlags.Consecratable);
 

--- a/hybrasyl/Objects/ItemObject.cs
+++ b/hybrasyl/Objects/ItemObject.cs
@@ -350,12 +350,10 @@ public class ItemObject : VisibleObject
             trigger.UpdateAttributes(StatUpdateFlags.Full);
         }
 
-        if (Use == null) return;
-
         // Run through all the different potential uses. We allow combinations of any
         // use specified in the item XML.
 
-        if (Use.Script != null)
+        if (Use?.Script != null)
         {
             Script invokeScript;
             if (!World.ScriptProcessor.TryGetScript(Use.Script, out invokeScript))
@@ -367,16 +365,16 @@ public class ItemObject : VisibleObject
             invokeScript.ExecuteFunction("OnUse", trigger, null, this, true);
         }            
 
-        if (Use.Effect != null)
+        if (Use?.Effect != null)
         {
             trigger.SendEffect(trigger.Id, Use.Effect.Id, Use.Effect.Speed); 
         }
         
-        if (Use.Sound != null)
+        if (Use?.Sound != null)
         {
             trigger.SendSound((byte) Use.Sound.Id);
         }
-        if (Use.Teleport != null)
+        if (Use?.Teleport != null)
         {
             trigger.Teleport(Use.Teleport.Value, Use.Teleport.X, Use.Teleport.Y);
         }

--- a/hybrasyl/Objects/ItemObject.cs
+++ b/hybrasyl/Objects/ItemObject.cs
@@ -134,7 +134,7 @@ public class ItemObject : VisibleObject
                      userobj.Equipment.RRing != null) || (restriction.Slot == Xml.EquipmentSlot.Gauntlet &&
                                                           userobj.Equipment.LGauntlet != null ||
                                                           userobj.Equipment.RGauntlet != null)
-                                                      || userobj.Equipment[(byte) restriction.Slot] != null)
+                                                      || userobj.Equipment[(byte) restriction.Slot] == null)
                 {
                     message = restrictionMessage;
                     return false;
@@ -156,7 +156,7 @@ public class ItemObject : VisibleObject
                     (restriction.Slot == Xml.EquipmentSlot.Gauntlet &&
                      EquipmentSlot == (byte) Xml.EquipmentSlot.LeftArm ||
                      EquipmentSlot == (byte) Xml.EquipmentSlot.RightArm) ||
-                    userobj.Equipment[(byte) restriction.Slot] != null)
+                    EquipmentSlot == (byte) restriction.Slot)
                 {
                     message = restrictionMessage;
                     return false;
@@ -166,7 +166,7 @@ public class ItemObject : VisibleObject
             {
                 if ((restriction.Slot == Xml.EquipmentSlot.Ring && userobj.Equipment.LRing != null ||
                      userobj.Equipment.RRing != null) || (restriction.Slot == Xml.EquipmentSlot.Gauntlet && userobj.Equipment.LGauntlet != null || userobj.Equipment.RGauntlet != null)
-                                                      || userobj.Equipment[(byte)restriction.Slot] != null)
+                                                      || EquipmentSlot != (byte) restriction.Slot)
                 {
                     message = restrictionMessage;
                     return false;

--- a/hybrasyl/Objects/ItemObject.cs
+++ b/hybrasyl/Objects/ItemObject.cs
@@ -410,7 +410,7 @@ public class ItemObject : VisibleObject
         TemplateId = template.Id;
         ServerGuid = containingWorld;
         _count = new Lockable<int>(1);
-        _durability = new Lockable<double>(uint.MaxValue);
+        _durability = new Lockable<double>(MaximumDurability);
         Guid = guid != default ? guid : Guid.NewGuid();
     }
 

--- a/hybrasyl/Objects/Monster.cs
+++ b/hybrasyl/Objects/Monster.cs
@@ -269,13 +269,19 @@ public class Monster : Creature, ICloneable
 
             Game.World.RemoveStatusCheck(this);
             // TODO: ondeath castables
+            InitScript();
+            // FIXME: in the glorious future, run asynchronously with locking
+            // TODO: fix awful hack here in scripting refactor
+            if (Script == null) return;
+            Script.SetGlobalValue("lasthitter", LastHitter);
+            Script.ExecuteFunction("OnDeath");
             Map?.Remove(this);
             World?.Remove(this);
         }
     }
 
     // We follow a different pattern here due to the fact that monsters
-    // are not intended to be long-lived objects, and we don't want to 
+    // are not intended to be long-lived objects, and we don't want to a
     // spend a lot of overhead and resources creating a full script (eg via
     // OnSpawn) when not needed 99% of the time.
     private void InitScript()

--- a/hybrasyl/Objects/Monster.cs
+++ b/hybrasyl/Objects/Monster.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Hybrasyl.Casting;
 using Hybrasyl.ChatCommands;
+using Hybrasyl.Messaging;
 
 namespace Hybrasyl.Objects;
 
@@ -301,23 +302,21 @@ public class Monster : Creature, ICloneable
         }
         return base.UseCastable(castable, target);
     }
-    public override void OnHear(VisibleObject speaker, string text, bool shout = false)
+    public override void OnHear(SpokenEvent e)
     {
-        if (speaker == this)
+        if (e.Speaker == this)
             return;
 
         // FIXME: in the glorious future, run asynchronously with locking
         InitScript();
-        if (Script != null)
-        {
-            Script.SetGlobalValue("text", text);
-            Script.SetGlobalValue("shout", shout);
+        if (Script == null) return;
+        Script.SetGlobalValue("text", e.Message);
+        Script.SetGlobalValue("shout", e.Shout);
 
-            if (speaker is User user)
-                Script.ExecuteFunction("OnHear", new HybrasylUser(user));
-            else
-                Script.ExecuteFunction("OnHear", new HybrasylWorldObject(speaker));
-        }
+        if (e.Speaker is User user)
+            Script.ExecuteFunction("OnHear", new HybrasylUser(user));
+        else
+            Script.ExecuteFunction("OnHear", new HybrasylWorldObject(e.Speaker));
     }
 
     public void MakeHostile()

--- a/hybrasyl/Objects/Monster.cs
+++ b/hybrasyl/Objects/Monster.cs
@@ -846,10 +846,9 @@ public class Monster : Creature, ICloneable
 
                     break;
                 }
-                case MobAction.Move when ThreatInfo.HighestThreat == null:
-                    return;
                 case MobAction.Move:
                 {
+                    if (ThreatInfo.HighestThreat == null) return;
                     if (Condition.MovementAllowed)
                     {
                         if (CurrentPath == null || !AStarPathClear())
@@ -865,8 +864,9 @@ public class Monster : Creature, ICloneable
 
                         if (CurrentPath != null)
                         {
-                            // We have a path, check its validity
-                            // We recalculate our path if we're within five spaces of the target and they have moved
+                                // We have a path, check its validity
+                                // We recalculate our path if we're within five spaces of the target and they have moved
+
                             if (Distance(ThreatInfo.HighestThreat) < 5 &&
                                 CurrentPath.Target.X != ThreatInfo.HighestThreat.Location.X &&
                                 CurrentPath.Target.Y != ThreatInfo.HighestThreat.Location.Y)
@@ -920,6 +920,7 @@ public class Monster : Creature, ICloneable
 
                 if (ThreatInfo.HighestThreat == null && ThreatInfo.Count == 0)
                 {
+                    GameLog.Error("Threat empty");
                     ShouldWander = true;
                     FirstHitter = null;
                     Target = null;

--- a/hybrasyl/Objects/Monster.cs
+++ b/hybrasyl/Objects/Monster.cs
@@ -294,7 +294,7 @@ public class Monster : Creature, ICloneable
 
     public override bool UseCastable(Castable castable, Creature target)
     {
-        if (Condition.CastingAllowed) return false;
+        if (!Condition.CastingAllowed) return false;
         if (castable.IsAssail)
         {
             Motion(1,20);
@@ -352,7 +352,7 @@ public class Monster : Creature, ICloneable
             if (Script == null) return;
 
             Script.SetGlobalValue("damage", damageEvent.Damage);
-            Script.ExecuteFunction("OnDamage", this, damageEvent.Attacker);
+            Script.ExecuteFunction("OnDamage", this, damageEvent.Attacker, null);
         }
     }
 
@@ -948,7 +948,6 @@ public class Monster : Creature, ICloneable
 
                 if (ThreatInfo.HighestThreat == null && ThreatInfo.Count == 0)
                 {
-                    GameLog.Error("Threat empty");
                     ShouldWander = true;
                     FirstHitter = null;
                     Target = null;

--- a/hybrasyl/Objects/StatInfo.cs
+++ b/hybrasyl/Objects/StatInfo.cs
@@ -1115,7 +1115,7 @@ public class StatInfo
                                  BaseOutboundDamageModifier == 0 && BaseOutboundHealModifier == 0 &&
                                  BaseReflectMagical == 0 && BaseReflectPhysical == 0 && BaseExtraGold == 0 &&
                                  BaseDodge == 0 && BaseMagicDodge == 0 && BaseExtraXp == 0 && BaseExtraItemFind == 0 &&
-                                 BaseLifeSteal == 0 && BaseManaSteal == 0 && BaseInboundDamageToMp == 0;
+                                 BaseLifeSteal == 0 && BaseManaSteal == 0 && BaseInboundDamageToMp == 0 && DeltaHp == 0 && DeltaMp == 0;
 
     public bool NoBonusChanges => BonusHp == 0 && BonusMp == 0 && BonusStr == 0 && BonusCon == 0 && BonusDex == 0 &&
                                   BonusInt == 0 && BonusWis == 0 && BonusCrit == 0 && BonusMagicCrit == 0 &&

--- a/hybrasyl/Objects/ThreatInfo.cs
+++ b/hybrasyl/Objects/ThreatInfo.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using App.Metrics.ReservoirSampling.Uniform;
 using Hybrasyl.Xml;
+using MoonSharp.Interpreter;
 
 namespace Hybrasyl.Objects;
 
@@ -40,6 +41,7 @@ public class ThreatEntry : IComparable
     }
 }
 
+[MoonSharpUserData]
 public class ThreatInfo
 {
     public Guid Owner { get; set; }

--- a/hybrasyl/Objects/ThreatInfo.cs
+++ b/hybrasyl/Objects/ThreatInfo.cs
@@ -147,6 +147,7 @@ public class ThreatInfo
         if (!ThreatTableByCreature.TryGetValue(threat.Guid, out ThreatEntry entry)) return;
         ThreatTableByCreature.Remove(threat.Guid);
         ThreatTableByThreat.Remove(entry);
+        GameLog.Error($"{OwnerObject.Id}: Removed threat {threat.Id}");
     }
 
     public void RemoveAllThreats()

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -474,9 +474,9 @@ public class User : Creature
         x0D.WriteBoolean(e.Shout);
         x0D.WriteUInt32(Id);
         if (e.Shout)
-            x0D.WriteString8(!string.IsNullOrEmpty(e.From) ? $"{e.From}! {e.Message}" : $"{Name}! {e.Message}");
+            x0D.WriteString8(!string.IsNullOrEmpty(e.From) ? $"{e.From}! {e.Message}" : $"{e.Speaker.Name}! {e.Message}");
         else
-            x0D.WriteString8(!string.IsNullOrEmpty(e.From) ? $"{e.From}: {e.Message}" : $"{Name}: {e.Message}");
+            x0D.WriteString8(!string.IsNullOrEmpty(e.From) ? $"{e.From}: {e.Message}" : $"{e.Speaker.Name}: {e.Message}");
         Enqueue(x0D);
     }
 

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -2451,9 +2451,23 @@ public class User : Creature
             SendSpells();
         return true;
     }
+
     public bool RemoveEquipment(byte slot, bool sendUpdate = true)
     {
         var item = Equipment[slot];
+        // Process requirements
+        if (item != null)
+        {
+            var f = Equipment.Where(x => x.Template.SlotRequirements.Any())
+                .SelectMany(itemReq => itemReq.Template.SlotRequirements);
+            if (Equipment.Where(x => x.Template.SlotRequirements.Any()).SelectMany(itemReq => itemReq.Template.SlotRequirements).Any(req => req.Slot == (EquipmentSlot) (slot)))
+            {
+                // TODO: improve messaging here
+                SendSystemMessage($"Other equipment must be removed first.");
+                return false;
+            }
+        }
+
         if (Equipment.Remove(slot))
         {
             SendRefreshEquipmentSlot(slot); 

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -3176,6 +3176,12 @@ public void OpenManufacture(IEnumerable<ManufactureRecipe> recipes)
                 prompt = merchant.GetLocalString("learn_skill_prereq_item");
             }
         }
+
+        if (SkillBook.IsPrimaryFull && castable.Book == Xml.Book.PrimarySkill ||
+            SkillBook.IsSecondaryFull && castable.Book == Xml.Book.SecondarySkill ||
+            SkillBook.IsUtilityFull && castable.Book == Xml.Book.UtilitySkill)
+            prompt = merchant.GetLocalString("learn_skill_book_full");
+
         if (prompt == string.Empty)
         {
             RemoveGold(classReq.Gold);
@@ -3440,6 +3446,12 @@ public void OpenManufacture(IEnumerable<ManufactureRecipe> recipes)
                 prompt = merchant.GetLocalString("learn_spell_prereq_item");
             }
         }
+
+        if (SpellBook.IsPrimaryFull && castable.Book == Xml.Book.PrimarySpell ||
+            SpellBook.IsSecondaryFull && castable.Book == Xml.Book.SecondarySpell ||
+            SpellBook.IsUtilityFull && castable.Book == Xml.Book.UtilitySpell)
+            prompt = merchant.GetLocalString("learn_spell_book_full");
+
         if (prompt == string.Empty)
         {
             RemoveGold(classReq.Gold);

--- a/hybrasyl/Objects/User.cs
+++ b/hybrasyl/Objects/User.cs
@@ -4067,7 +4067,6 @@ public void OpenManufacture(IEnumerable<ManufactureRecipe> recipes)
         if (Vault.CurrentGold > 1) coins = "coins";
         var prompt = merchant.GetLocalString("deposit_gold",("$COINS", Vault.CurrentGold.ToString()),("$REF", coins));
 
-
         var input = new MerchantInput();
         input.Id = (ushort)MerchantMenuItem.DepositGoldQuantity;
 
@@ -4982,6 +4981,21 @@ public void OpenManufacture(IEnumerable<ManufactureRecipe> recipes)
             Action = ExchangeActions.Confirm,
             Side = source
         }.Packet());
+    }
+
+    public void SendInventorySlot(byte slot)
+    {
+        if (Inventory[slot] == null) return;
+        var x0F = new ServerPacket(0x0F);
+        x0F.WriteByte(slot);
+        x0F.WriteUInt16((ushort)(Inventory[slot].Sprite + 0x8000));
+        x0F.WriteByte(Inventory[slot].Color);
+        x0F.WriteString8(Inventory[slot].Name);
+        x0F.WriteInt32(Inventory[slot].Count);
+        x0F.WriteBoolean(Inventory[slot].Stackable);
+        x0F.WriteUInt32(Inventory[slot].MaximumDurability);
+        x0F.WriteUInt32(Inventory[slot].DisplayDurability);
+        Enqueue(x0F);
     }
 
     public void SendInventory()

--- a/hybrasyl/Objects/VisibleObject.cs
+++ b/hybrasyl/Objects/VisibleObject.cs
@@ -23,6 +23,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using Hybrasyl.Enums;
+using Hybrasyl.Messaging;
 using Newtonsoft.Json;
 
 namespace Hybrasyl.Objects;
@@ -144,7 +145,7 @@ public class VisibleObject : WorldObject
     public virtual void OnDamage(DamageEvent damageEvent) { }
     public virtual void OnHeal(Creature healer, uint damage) { }
 
-    public virtual void OnHear(VisibleObject speaker, string text, bool shout = false) { }
+    public virtual void OnHear(SpokenEvent e) { }
 
     public Rectangle GetBoundingBox()
     {
@@ -217,16 +218,7 @@ public class VisibleObject : WorldObject
     {
         foreach (var obj in Map.EntityTree.GetObjects(GetViewport()))
         {
-            if (obj is User user)
-            {
-                var x0D = new ServerPacket(0x0D);
-                x0D.WriteByte(0x00);
-                x0D.WriteUInt32(Id);
-                x0D.WriteString8(!string.IsNullOrEmpty(@from) ? $"{@from}: {message}" : $"{Name}: {message}");
-                user.Enqueue(x0D);
-            }
-            else
-                obj.OnHear(this, message, false);
+            obj.OnHear(new SpokenEvent(this, message, from));
         }
     }
 
@@ -234,19 +226,7 @@ public class VisibleObject : WorldObject
     {           
         foreach (var obj in Map.EntityTree.GetObjects(GetShoutViewport()))
         {
-            if (obj is User user)
-            {
-                var x0D = new ServerPacket(0x0D);
-                x0D.WriteByte(0x01);
-                x0D.WriteUInt32(Id);
-                if (!string.IsNullOrEmpty(from))
-                    x0D.WriteString8($"{from}! {message}");
-                else
-                    x0D.WriteString8($"{Name}! {message}");
-                user.Enqueue(x0D);
-            }
-            else
-                obj.OnHear(this, message, true);
+            obj.OnHear(new SpokenEvent(this, message, from, true));
         }
     }
 

--- a/hybrasyl/Objects/WorldObject.cs
+++ b/hybrasyl/Objects/WorldObject.cs
@@ -109,6 +109,7 @@ public class WorldObject : IQuadStorable
 
     public virtual int Distance(WorldObject obj)
     {
+        if (obj == null) return 255;
         return Point.Distance(obj.X, obj.Y, X, Y);
     }
 

--- a/hybrasyl/Packet.cs
+++ b/hybrasyl/Packet.cs
@@ -729,6 +729,8 @@ public class ServerPacket : Packet
                     return EncryptMethod.MD5Key;
                 }
             }
+
+            if (opcode == 0x1a) return EncryptMethod.Normal;
             return EncryptMethod.None;
         }
     }

--- a/hybrasyl/Packet.cs
+++ b/hybrasyl/Packet.cs
@@ -730,7 +730,7 @@ public class ServerPacket : Packet
                 }
             }
 
-            if (opcode == 0x1a) return EncryptMethod.Normal;
+            //if (opcode == 0x1a) return EncryptMethod.Normal;
             return EncryptMethod.None;
         }
     }

--- a/hybrasyl/Scripting/HybrasylUser.cs
+++ b/hybrasyl/Scripting/HybrasylUser.cs
@@ -895,14 +895,10 @@ public class HybrasylUser
     /// <returns></returns>
     public bool HasItem(string name, int count = 1)
     {
-        if (string.IsNullOrEmpty(name))
-        {
-            GameLog.ScriptingError("HasItem: {user} - item name (first parameter) was null or empty - returning false", User.Name);
-            return false;
-        }
-        if (count == 1)
-            return User.Inventory.ContainsName(name);
-        return User.Inventory.ContainsId(name, count);
+        if (!string.IsNullOrEmpty(name)) return User.Inventory.ContainsName(name, count);
+        GameLog.ScriptingError("HasItem: {user} - item name (first parameter) was null or empty - returning false", User.Name);
+        return false;
+
     }
 
     /// <summary>

--- a/hybrasyl/Scripting/HybrasylWorldObject.cs
+++ b/hybrasyl/Scripting/HybrasylWorldObject.cs
@@ -325,6 +325,9 @@ public class HybrasylWorldObject
             GameLog.ScriptingError("Distance: either target (first argument) or this object was not a VisibleObject (not on a map), returning -1");
         return -1;
     }
+
+    // TODO: refactor and collapse, also add dialog sprite
+
     /// <summary>
     /// Set the default sprite for this world object to a specified creature sprite.
     /// </summary>
@@ -332,7 +335,7 @@ public class HybrasylWorldObject
     public void SetNpcDisplaySprite(int displaySprite)
     {
         if (Obj is VisibleObject vobj)
-            vobj.DialogSprite = (ushort)(0x4000 + displaySprite);
+            vobj.Sprite = (ushort)(0x4000 + displaySprite);
         else
             GameLog.ScriptingError("SetNpcDisplaySprite: underlying object is not a visible object, ignoring");
     }
@@ -344,7 +347,7 @@ public class HybrasylWorldObject
     public void SetItemDisplaySprite(int displaySprite)
     {
         if (Obj is VisibleObject vobj)
-            vobj.DialogSprite = (ushort)(0x4000 + displaySprite);
+            vobj.Sprite = (ushort)(0x4000 + displaySprite);
         else
             GameLog.ScriptingError("SetItemDisplaySprite: underlying object is not a visible object, ignoring");
     }

--- a/hybrasyl/Scripting/Script.cs
+++ b/hybrasyl/Scripting/Script.cs
@@ -300,6 +300,12 @@ public class Script
         var v = DynValue.NewBoolean(value);
         Compiled.Globals.Set(name, v);
     }
+
+    // TODO: remove godawful hack in scripting refactor
+    public void SetGlobalValue(string name, Creature c)
+    {
+        Compiled.Globals.Set(name, GetUserDataValue(c));
+    }
         
     /// <summary>
     /// Execute a Lua expression in the context of an associated world object.

--- a/hybrasyl/ServerPacketStructures.cs
+++ b/hybrasyl/ServerPacketStructures.cs
@@ -33,7 +33,7 @@ internal interface IPacket
     ServerPacket ToPacket();
 }
 
-internal class ServerPacketStructures
+public class ServerPacketStructures
 {
 
     internal partial class AddSpell
@@ -135,15 +135,10 @@ internal class ServerPacketStructures
 
     internal partial class PlayerAnimation
     {
-        private byte OpCode;
-
-        internal PlayerAnimation()
-        {
-            OpCode = OpCodes.PlayerAnimation;
-        }
+        private byte OpCode = OpCodes.PlayerAnimation;
 
         internal uint UserId { get; set; }
-        internal ushort Speed { get; set; }
+        internal short Speed { get; set; }
         internal byte Animation { get; set; }
 
         internal ServerPacket Packet()
@@ -151,8 +146,8 @@ internal class ServerPacketStructures
             ServerPacket packet = new ServerPacket(OpCode);
             packet.WriteUInt32(UserId);
             packet.WriteByte(Animation);
-            packet.WriteUInt16(Speed);
-
+            packet.WriteInt16(Speed);
+            packet.WriteByte(byte.MaxValue);
             return packet;
         }
 

--- a/hybrasyl/Utility.cs
+++ b/hybrasyl/Utility.cs
@@ -273,6 +273,18 @@ namespace Hybrasyl
         public const int JUMP_DIALOG = 8;
     }
 
+    public enum MessageType
+    {
+        Whisper = 0,
+        System = 1,
+        SystemOverhead = 3,
+        SlateScrollbar = 9,
+        Slate = 10,
+        Group = 11,
+        Guild = 12,
+        Overhead = 18
+    }
+
     static class MessageTypes
     {
         public const int WHISPER = 0;

--- a/hybrasyl/World.cs
+++ b/hybrasyl/World.cs
@@ -1765,7 +1765,9 @@ public partial class World : Server
 
         string error = string.Empty;
 
-        VisibleObject pickupObject = pickupList.FirstOrDefault(po => po.CanBeLooted(user.Name, out error));
+        // Pick up gold first
+        VisibleObject pickupObject = pickupList.FirstOrDefault(po => po is Gold && po.CanBeLooted(user.Name, out error)) ??
+                                     pickupList.FirstOrDefault(po => po is ItemObject && po.CanBeLooted(user.Name, out error));
 
         if (pickupObject == null)
         {


### PR DESCRIPTION
## Hybrasyl 0.9.1

_Release notes for the latest point release in the Danaan series (0.9.1)_

* Tickets
  * HS-802: Address regression in 0.9.0 which made training dummies not work - they now work again
  * HS-924: A player who confirms an exchange could still add items to the exchange
  * HS-1113: Certain potions do not work if your max hp/mp is under the amount being given by the potion
  * HS-1123: When looting a pile, loot gold first as opposed to items
  * HS-1194: When a player's spellbook is full, they can continue to learn spells (and pay requirement costs) but nothing happens
  * HS-1247: `SetNPCDisplaySprite` in Lua not working
  * HS-1248: Add the ability to specify a number of recent kills to `HasKilled` in Lua
  * HS-1250: Implement all NPC voice commands (repair / deposit / withdraw / buy)
  * HS-1254: allow all cast costs to be specified as formulas
  * HS-1261: implement `OnDeath` as a scripting hook 
* Bug fixes
  * Add locking to quadtree to address certain edge cases where spawn thread was causing multiple enumeration errors
  * Fix various null reference edge cases in xml
  * Address monsters not turning correctly
  * Correctly address ability for lootsets to create an infinite roll scenario
* Code improvements
  * Add unit tests for statuses, item slot requirements, merchant functions (deposit/withdraw/etc)
* New features
  * Add lootset evaluator (whisper `#` as a privileged user), which allows you to evaluate multiple rolls on a loot set / table




