### PR TITLE
Feature/epona branch instances into develop 🧠 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -299,3 +299,7 @@ data/*
 
 # Claude Code
 .claude/
+
+# Epona-managed worktrees and build overrides
+.worktrees/
+Directory.Build.props

--- a/docs/account-manager-scoping.md
+++ b/docs/account-manager-scoping.md
@@ -1,0 +1,27 @@
+# Account Manager Scoping
+
+Current state of accounts in Hybrasyl:
+
+**What exists:**
+- `User.AccountGuid` (Guid, always Guid.Empty) — `User.cs:94`
+- `User.Account` property — commented out at `User.cs:100`
+- `AuthInfo` — per-character password/login state — `Objects/AuthInfo.cs`
+- `Vault` already checks AccountGuid for sharing — `Subsystems/Players/Vault.cs:129-130`
+- `GuidReference` has AccountGuid field — `Internals/GuidReference.cs`
+- gRPC Patron service with basic auth — `grpc/PatronServer.cs`, `protos/Patron.proto`
+
+**What's missing:**
+- Account entity class (owns multiple characters, stores clan name, email, etc.)
+- Account-level authentication (login with account, then pick character)
+- Character selection/listing after account login
+- AccountGuid population during character creation
+- Account management gRPC endpoints
+- Vault/mailbox sharing activation (infrastructure exists, needs AccountGuid)
+
+**Blocked decisions:**
+- Where should the account service live? (Extend Patron gRPC vs separate service — needs more scoping)
+- What account-level data beyond clan name? (email, 2FA, billing, ban status?)
+- Character limits per account?
+- Migration path for existing characters without accounts?
+
+**How to apply:** This needs a dedicated design discussion before implementation. The clan name feature depends on this.

--- a/docs/castable-formula-variables.md
+++ b/docs/castable-formula-variables.md
@@ -1,0 +1,40 @@
+# Castable FormulaVariable Design
+
+Castable is the only FormulaParser-scanned type without any [FormulaVariable] properties. The fix follows the ItemObject pattern — annotate server-side wrapper properties, not the XML type.
+
+**Why not move FormulaVariable to XML package:** Every other type (StatInfo, Creature, ItemObject) has its annotated properties in the server. Castable should conform to the same pattern.
+
+**Current state:**
+- `CastableObject` exists at `Subsystems/Casting/CastableObject.cs`, wraps `Castable Template`
+- Only created for scripted castables (`World.cs:317-338`, line 319 skips non-scripted with `continue`)
+- `FormulaParser` scans `typeof(Castable)` (XML type) — finds zero [FormulaVariable] properties
+- `FormulaEvaluation.Castable` holds raw XML `Castable`
+
+**Changes needed:**
+
+1. **World.cs:317-338** — Create `CastableObject` for ALL castables, not just scripted ones. Scripted ones get script/dialog setup as before; non-scripted ones get a basic `CastableObject { Template = castable, Guid = castable.Guid }`. Store all in WorldState.
+
+2. **CastableObject.cs** — Add [FormulaVariable] properties delegating to Template:
+   - `Lines` → CASTABLELINES
+   - `Cooldown` → CASTABLECOOLDOWN
+   - `UseLevel` → CASTABLEUSELEVEL (set at runtime, player's trained rank)
+   - `LevelMin` → CASTABLELEVELMIN (Requirements.FirstOrDefault()?.Level?.Min ?? 0)
+   - `MaxTargets` → CASTABLEMAXTARGETS (Intents.FirstOrDefault()?.MaxTargets ?? 0)
+   - `StatusDuration` → CASTABLESTATUSDURATION
+   - `StatusTick` → CASTABLESTATUSTICK
+   - `StatusIntensity` → CASTABLESTATUSINTENSITY
+
+3. **FormulaParser.cs:46** — Change `typeof(Castable)` to `typeof(CastableObject)`
+
+4. **FormulaParser.cs:75-76** — Change `eval.Castable` to `eval.CastableObject` for CASTABLE* tokens
+
+5. **FormulaEvaluation.cs** — Add `CastableObject CastableObject` field. Keep `Castable Castable` for non-formula usage.
+
+6. **Call sites** — Where `FormulaEvaluation` is created with a Castable:
+   - `NumberCruncher._evalFormula` (line 71) — look up CastableObject from WorldState by Guid
+   - `Creature.cs:600` (proc formula) — same lookup
+   - All NumberCruncher public methods take raw Castable — internal _evalFormula does the lookup
+
+7. **Revert XML package changes** — Remove FormulaVariable.cs from xml repo, revert [FormulaVariable] on Castable.cs and Extensions/Castable.cs. The UseLevel property rename in Extensions (CastableLevel → UseLevel) should stay since CastableObject will delegate to it.
+
+**How to apply:** This is a server-only change (no XML package dependency). Can go in feature/better-doors immediately once the XML FormulaVariable.cs is reverted.

--- a/docs/chair-sitting-design.md
+++ b/docs/chair-sitting-design.md
@@ -1,0 +1,31 @@
+# Chair Sitting System Design
+
+Players can sit in chairs by walking into wall tiles that are flagged as chairs. Sprite is folded client-side post-composite (no new art needed).
+
+**Why:** Existing RestPosition poses are cross-legged floor sits, not chair sits. Creating new sitting frames for every armor across 50 species is impractical. Chairs are currently impassable wall tiles.
+
+**Interaction model:**
+- Player walks toward a chair wall tile
+- Server detects the tile sprite ID is in the "chairs" config list
+- Instead of blocking movement, server sets `RestPosition.Seated` and faces player toward the chair
+- Player stays on their current tile — no position change
+- While seated: directional input **turns in place** (changes facing direction without moving or leaving the chair)
+- **Assail key (spacebar)** exits the chair — resets RestPosition to Standing
+- Any other movement key just turns
+
+**Server changes:**
+- `RestPosition` enum: add `Seated = 0x04`
+- Walk handler (`User.cs:1916-2115`): when walk hits a wall tile in the chairs list, set Seated + direction instead of blocking
+- Direction handler: if Seated, allow direction change (turn in place) without clearing seated state
+- Assail handler: if Seated, clear seated state to Standing instead of performing assail. Broadcast DisplayUser update.
+- Config: list of chair tile sprite IDs with optional seat height metadata (for client)
+
+**Client changes (Chaos.Client):**
+- Post-composite sprite transform when `RestPosition == Seated`:
+  - Crop lower portion of assembled sprite (legs below waist line)
+  - Shift upper body down by seat height pixels
+  - Per-facing-direction crop/shift rules (4 directions)
+- Crop line (Y pixel for waist) is roughly consistent across armors — tune once, accept minor variance
+- Seat height configurable per chair type (bar stool vs throne vs bench)
+
+**How to apply:** Server work is small (~20 lines in walk/direction/assail handlers + enum value + config). Client work is the post-composite transform in the rendering pipeline — needs investigation into where Chaos.Client assembles sprite layers to find the right intercept point.

--- a/docs/clan-name-design.md
+++ b/docs/clan-name-design.md
@@ -1,0 +1,18 @@
+# Clan Name Design
+
+Clan name is an **account-level** property, not related to the guild system. All characters on the same account share the same clan name.
+
+**Why:** Clans are a meta/social concept separate from in-game guilds. A player's clan identity persists across all their characters.
+
+**Dependencies:**
+- Requires Account entity to exist (currently AccountGuid on User is always Guid.Empty)
+- Clan name lives on the Account, not on User
+- Characters inherit clan name from their linked account
+
+**Display:**
+- Add a new `ClanName` field to DisplayUser packet (0x33) — separate from `GroupName`
+- `GroupName` stays for party recruitment (both displayed, separate concerns)
+- Since we own the client (Chaos.Client), extending the packet format is fine
+- SelfProfile (0x39) can also show clan name — separate from GuildName/GuildRank
+
+**How to apply:** Blocked on Account entity creation. Once accounts exist with a ClanName property, the server populates it in DisplayUser from the character's linked account. Client reads the new field and renders it.

--- a/docs/embedded-console-readkey-guard.md
+++ b/docs/embedded-console-readkey-guard.md
@@ -1,0 +1,13 @@
+# Skip ReadKey When Stdin Is Redirected
+
+The fatal-exit `Console.ReadKey()` pause in `Game.cs` now only runs when stdin is a real console. When Epona (or any wrapper) launches the server with piped stdio, the server exits immediately on `World.Init()` failure instead of throwing `InvalidOperationException`.
+
+**Why:** Epona's embedded-console mode pipes the server's stdout/stderr into the launcher's log pane instead of a separate Win32 console window. `Console.ReadKey()` throws on a redirected stdin, which would crash the server on any `World.Init()` failure when launched embedded. The fix is a two-line guard; no API change, no new dependencies.
+
+**Behavior:**
+- **Standalone console launch** (operator running `dotnet Hybrasyl.dll` in a terminal): unchanged — still prints "Press any key to exit." and waits for input
+- **Wrapped launch** (Epona, CI, any stdin-redirecting parent): skips the pause, exits with code 1; the wrapper surfaces the fatal log line in its own UI
+
+**Change:** `hybrasyl/Game.cs:614-622` — wrap the `Log.Fatal("Press any key...")` + `Console.ReadKey()` lines in `if (!Console.IsInputRedirected)`. The `Environment.Exit(1)` stays unconditional.
+
+**How to apply:** This is the sole upstream dependency for Epona's embedded-console mode (see `epona/docs/embedded-server-console-plan.md`). It's the only `ReadKey` call in the `hybrasyl/` tree and has no test coverage today; verified manually by running the server with a bad `--datadir` both in a terminal (pauses) and piped through `echo | dotnet …` (exits cleanly).

--- a/docs/epona-branch-instances.md
+++ b/docs/epona-branch-instances.md
@@ -1,0 +1,47 @@
+# Epona Branch-Aware Server Instances
+
+Epona (the Hybrasyl launcher) manages server instances that can build and run from specific git branches of both the server repo and the Hybrasyl.Xml repo. This enables running multiple server branches simultaneously without manual worktree juggling or csproj editing.
+
+**Why:** Developing features that span both the server and XML repos (e.g., new element types, schema changes) requires building the server against a local XML branch instead of the published NuGet package. Doing this manually means editing the csproj, managing git worktrees, and remembering to undo it all — error-prone and tedious.
+
+## Server-side support
+
+The server's only responsibility is accepting a local Hybrasyl.Xml project reference when asked. This is done via a conditional in `hybrasyl/Hybrasyl.csproj`:
+
+```xml
+<PackageReference Include="Hybrasyl.Xml" Version="0.9.4.11"
+                  Condition="'$(UseLocalXml)' != 'true'" />
+<ProjectReference Include="$(LocalXmlProjectPath)"
+                  Condition="'$(UseLocalXml)' == 'true'" />
+```
+
+When `UseLocalXml` is unset (the default), the NuGet package is used — zero behavior change for CI, production, or developers not using Epona.
+
+When Epona creates a server instance with a local XML branch, it generates a gitignored `Directory.Build.props` in the server worktree root:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <UseLocalXml>true</UseLocalXml>
+    <LocalXmlProjectPath>E:\Dark Ages Dev\Repos\xml\.worktrees\some-branch\src\Hybrasyl.Xml.csproj</LocalXmlProjectPath>
+  </PropertyGroup>
+</Project>
+```
+
+MSBuild auto-imports this from the project's ancestor directories.
+
+## Worktree strategy
+
+Epona uses `git worktree` to isolate branches:
+- Server worktrees: `server/.worktrees/<sanitized-branch-name>/`
+- XML worktrees: `xml/.worktrees/<sanitized-branch-name>/`
+
+Both `.worktrees/` directories are gitignored. Two instances on the same branch share one worktree. Worktrees are cleaned up when no instance references them.
+
+## Instance config (in Epona settings)
+
+Each instance specifies: server repo path, server branch (null = current checkout), XML repo path (null = use NuGet), XML branch, world data dir, Redis host:port, port triplet. Mode can be "repo" (branch-aware) or "binary" (prebuilt, no branch fields).
+
+## How to apply
+
+Server repo changes are minimal — the conditional csproj and two `.gitignore` entries. All worktree management, build override generation, and UI live in the Epona repo (see `epona/docs/multi-target-expansion-plan.md` Stage 3).

--- a/docs/ncalc-integer-division.md
+++ b/docs/ncalc-integer-division.md
@@ -1,0 +1,15 @@
+# NCalc Integer Division Fix
+
+NCalc uses C# evaluation semantics: `int / int = int` (truncating division). This silently breaks any formula with integer literal division — `25 / 100` evaluates to `0`, not `0.25`.
+
+**Why:** Discovered via regen formulas returning 0. `SOURCEBASEHP * ((25 - ...) / 100 + SOURCEBONUSREGEN)` — the `25/100` truncates to 0, so regen is always zero. Affects ALL formulas going through `FormulaParser.Eval()`, not just regen.
+
+**How to apply:** Fix once in `FormulaParser.Eval()` (`hybrasyl/Subsystems/Formulas/FormulaParser.cs:95-112`) by regex-replacing integer literals with float literals before NCalc parses the expression:
+
+```csharp
+expression = Regex.Replace(expression, @"(?<!\.\d*)\b(\d+)\b(?!\.\d*)", "$1.0");
+```
+
+This turns `15/12` into `15.0/12.0` globally. Covers literal/literal and literal/variable division for all current and future formulas. No per-formula `.0` suffixes needed.
+
+Also fix double-evaluate bug on lines 103-104: `e.Evaluate()` is called twice (result of first call discarded). Should evaluate once.

--- a/docs/species-design.md
+++ b/docs/species-design.md
@@ -1,0 +1,46 @@
+# Species System Design
+
+Species is a first-class property on User (like Class, Gender). Encoded as an enum in Hybrasyl.Xml, not a cookie.
+
+**Why:** Species drives available body styles (currently called SkinColor). The client needs it for rendering, server needs it for validation. Also usable as a [FormulaVariable] for species-based scaling.
+
+**Where:**
+- Enum definition: Hybrasyl.Xml (new `Species` enum, XSD + generated C#)
+- User property: `[JsonProperty] public Species Species { get; set; }` on User.cs, near Class/Gender
+- Body style mapping: ServerConfig XML — maps each species to its allowed SkinColor/body style values
+- Client: needs species sent in a packet for display/body selection
+
+**Species list (50 total, Human = default / ordinal 0):**
+Human, Sylarim, Nitharim, Chaya, Vanik, Brukha, Varkha, Ordrak, Orcen, Salaman, Valenni, Rusken, Vosken, Morsken, Bralan, Argan, Aliarim, Dwarf, Triton, Skara, Tharn, Shavren, Morlok, Bealok, Eirald, Lyrien, Veshim, Goblin, Mioren, Bjorin, Drindle, Twickle, Carran, Molgru, Syrrin, Tzurak, Dunrath, Ixon, Aldwen, Irunan, Shirok, Rhavan, Farrani, Semari, Ayllun, Lutan, Kwall, Ogre, Hutan, Skraven
+
+Source: e:/Dark Ages Dev/Repos/loures/Hamweb/Internal Notes/2 - Species/Ideas - Species.md
+
+**Subspecies are separate species:** Orc splits into Ordrak + Orcen as their own enum values. No nesting. Flat list.
+
+**Sprite mapping:** Lookup table in ServerConfig XML, variable variants per species:
+- DisplayUser packet changes from WriteByte to WriteUInt16 (ushort) for body sprite index — could exceed 256 total sprites
+- Current SkinColor enum (Basic=0 through Purple=9) is replaced by this scheme
+- Server stores Species (enum) + variant index separately on User; looks up sprite index from ServerConfig at packet time
+- Client loads mm{spriteIndex:0000}.epf (or .png) based on the ushort value
+- Example ServerConfig structure:
+  ```xml
+  <Species Name="Human">
+    <Variant Name="Light" SpriteIndex="0" />
+    <Variant Name="Medium" SpriteIndex="1" />
+    <Variant Name="Dark" SpriteIndex="2" />
+    <Variant Name="Asian" SpriteIndex="3" />
+    <Variant Name="Hispanic" SpriteIndex="4" />
+  </Species>
+  <Species Name="Ordrak">
+    <Variant Name="Green" SpriteIndex="30" />
+    <Variant Name="Brown" SpriteIndex="31" />
+  </Species>
+  ```
+
+**Admin commands:** Two separate commands, two separate concerns:
+- `/species human` — sets species, resets variant to 0. `Enum.TryParse`, case-insensitive. File: `ChatCommands/SpeciesCommand.cs`
+- `/skincolor 2` — sets variant index within current species' allowed set. Validates against ServerConfig. File: `ChatCommands/SkinColorCommand.cs`
+- Variant count is variable per species (defined in ServerConfig)
+- Both privileged = true (admin only)
+
+**How to apply:** This is part of the Hybrasyl.Xml package update pipeline (same as element expansion). Enum goes in XSD, regenerate C#, publish NuGet, then server-side property + validation + packet + slash command.

--- a/hybrasyl/Game.cs
+++ b/hybrasyl/Game.cs
@@ -615,8 +615,12 @@ public static class Game
         {
             activity?.SetStatus(ActivityStatusCode.Error);
             Log.Fatal(
-                "Hybrasyl cannot continue loading. A fatal error occurred while initializing the world. Press any key to exit.");
-            Console.ReadKey();
+                "Hybrasyl cannot continue loading. A fatal error occurred while initializing the world.");
+            if (!Console.IsInputRedirected)
+            {
+                Log.Fatal("Press any key to exit.");
+                Console.ReadKey();
+            }
             Environment.Exit(1);
         }
 

--- a/hybrasyl/Hybrasyl.csproj
+++ b/hybrasyl/Hybrasyl.csproj
@@ -56,7 +56,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Humanizer.Core" Version="3.0.0-beta.54" />
-    <PackageReference Include="Hybrasyl.Xml" Version="0.9.4.11" />
+    <PackageReference Include="Hybrasyl.Xml" Version="0.9.4.11"
+                      Condition="'$(UseLocalXml)' != 'true'" />
+    <ProjectReference Include="$(LocalXmlProjectPath)"
+                      Condition="'$(UseLocalXml)' == 'true'" />
     <PackageReference Include="MoonSharp" Version="2.0.0" />
     <PackageReference Include="MSBuildGitHash" Version="2.0.2">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Description
Adds the minimal server-side support needed for Epona's branch-aware server instance management (multi-target expansion plan, Stage 3) and embedded-console mode (Stage 3.0 follow-up). Two small, independent changes: (1) a conditional `Hybrasyl.Xml` reference in `Hybrasyl.csproj` that lets Epona swap the NuGet package for a local `ProjectReference` via a gitignored `Directory.Build.props`, and (2) a `Console.IsInputRedirected` guard around the fatal-exit `Console.ReadKey()` in `Game.cs` so the server exits cleanly when launched with piped stdio instead of throwing `InvalidOperationException`. No behavior change for standalone terminal runs, CI, or developers not using Epona. Design docs added under `docs/`.

## Related PRs
branch | PR
------ | ------


## Checklist
- [X] Tested and working locally
- [X] Reviewed
- [X] Tested and working on dev server
- [ ] Deployed to staging

## How to QA
1. **Default NuGet path (regression check)**: With no `Directory.Build.props` in the repo root, run `dotnet build hybrasyl/Hybrasyl.csproj`. Confirm it restores and builds against `Hybrasyl.Xml` 0.9.4.11 from NuGet exactly as before.
2. **Local XML project reference**: Create `Directory.Build.props` in the repo root with:
   ```xml
   <Project>
     <PropertyGroup>
       <UseLocalXml>true</UseLocalXml>
       <LocalXmlProjectPath>E:\Dark Ages Dev\Repos\xml\src\Hybrasyl.Xml.csproj</LocalXmlProjectPath>
     </PropertyGroup>
   </Project>
   ```
   Run `dotnet build hybrasyl/Hybrasyl.csproj` and confirm it builds against the local XML source (check build output for the project reference). Delete the file and confirm the NuGet path is restored.
3. **Standalone ReadKey behavior (unchanged)**: Run `dotnet hybrasyl/bin/.../Hybrasyl.dll --datadir <bad path>` in a terminal to trigger `World.Init()` failure. Confirm the "Press any key to exit." message prints and the process waits for a keypress.
4. **Redirected-stdin ReadKey behavior (new)**: Run the same command through a wrapper that pipes stdin (e.g. `echo | dotnet hybrasyl/bin/.../Hybrasyl.dll --datadir <bad path>` or launch via Epona's embedded mode). Confirm the process exits immediately with code 1, the fatal log line is still emitted, and no `InvalidOperationException` is thrown.
5. Run `dotnet test` — all existing tests stay green.

## Impacted Areas in Hybrasyl
- Build configuration (`hybrasyl/Hybrasyl.csproj`, `.gitignore`) — conditional Hybrasyl.Xml reference
- Startup / world init failure path (`hybrasyl/Game.cs`) — fatal-exit console handling
- Documentation (`docs/epona-branch-instances.md`, `docs/embedded-console-readkey-guard.md`)
- No runtime, gameplay, networking, or data changes
