### PR TITLE
fix(reactor): reset SequenceIndex on respawn to silence overwrite warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+
+[*.{csproj,sln,props,targets,xml,xsd}]
+indent_style = space
+indent_size = 2
+
+[*.{json,yml,yaml,md}]
+indent_style = space
+indent_size = 2
+
+[*.lua]
+indent_style = space
+indent_size = 4

--- a/Hybrasyl.Tests/Reactors.cs
+++ b/Hybrasyl.Tests/Reactors.cs
@@ -16,11 +16,15 @@
 // 
 // For contributors and individual authors please refer to CONTRIBUTORS.MD.
 
+using Hybrasyl.Interfaces;
 using Hybrasyl.Objects;
+using Hybrasyl.Subsystems.Dialogs;
 using Hybrasyl.Xml.Objects;
 using System.Linq;
 using Xunit;
 using Creature = Hybrasyl.Xml.Objects.Creature;
+using HybrasylReactor = Hybrasyl.Objects.Reactor;
+using XmlReactor = Hybrasyl.Xml.Objects.Reactor;
 
 namespace Hybrasyl.Tests;
 
@@ -144,5 +148,77 @@ public class Reactor
         Fixture.TestUser.Stats.Level = 39;
 
         var trapTest = Game.World.WorldData.GetByIndex<Castable>("TestTrapSingle");
+    }
+
+    // --- Reactor.OnSpawn idempotency tests ---
+    //
+    // Regression for the QRM20_* "Dialog sequence X is being overwritten" startup warnings:
+    // Reactor.OnSpawn used to call DialogSequences.Clear() before re-running the script's OnSpawn
+    // function, but left SequenceIndex populated. RegisterDialogSequence checks SequenceIndex
+    // for duplicates, so every re-registration after a second OnSpawn (caused by InsertReactor
+    // explicitly calling OnSpawn even though World.Insert had already fired it via the ISpawnable
+    // path, and by ScriptProcessor.ReloadScript on script reload) tripped a warning per sequence.
+    // Fix uses IPursuitable.ResetPursuits, which empties all three collections together.
+
+    private static HybrasylReactor CreateBareReactor(byte x = 5, byte y = 5) =>
+        new(new XmlReactor { X = x, Y = y, DisplayName = "TestReactor" }, Fixture.Map);
+
+    [Fact]
+    public void ResetPursuits_ClearsAllSequenceCollections()
+    {
+        var reactor = CreateBareReactor();
+        var pursuitable = (IPursuitable)reactor;
+
+        ((IInteractable)reactor).RegisterDialogSequence(new DialogSequence("seq_a"));
+        pursuitable.AddPursuit(new DialogSequence("pursuit_a"));
+
+        Assert.NotEmpty(reactor.SequenceIndex);
+        Assert.NotEmpty(reactor.DialogSequences);
+        Assert.NotEmpty(reactor.Pursuits);
+
+        pursuitable.ResetPursuits();
+
+        Assert.Empty(reactor.SequenceIndex);
+        Assert.Empty(reactor.DialogSequences);
+        Assert.Empty(reactor.Pursuits);
+    }
+
+    [Fact]
+    public void DialogSequencesClear_AloneLeavesSequenceIndexStale()
+    {
+        // Demonstrates the pre-fix bug: clearing only DialogSequences leaves SequenceIndex
+        // populated. Future maintainers reading this test should see why ResetPursuits is the
+        // correct call, not DialogSequences.Clear().
+        var reactor = CreateBareReactor();
+        ((IInteractable)reactor).RegisterDialogSequence(new DialogSequence("seq_a"));
+
+        reactor.DialogSequences.Clear();
+
+        Assert.Empty(reactor.DialogSequences);
+        Assert.NotEmpty(reactor.SequenceIndex);
+    }
+
+    [Fact]
+    public void ReRegisterAfterResetPursuits_LeavesNoDuplicates()
+    {
+        var reactor = CreateBareReactor();
+        var interactable = (IInteractable)reactor;
+
+        interactable.RegisterDialogSequence(new DialogSequence("seq_a"));
+        interactable.RegisterDialogSequence(new DialogSequence("seq_b"));
+        Assert.Equal(2, reactor.SequenceIndex.Count);
+        Assert.Equal(2, reactor.DialogSequences.Count);
+
+        ((IPursuitable)reactor).ResetPursuits();
+
+        var freshA = new DialogSequence("seq_a");
+        var freshB = new DialogSequence("seq_b");
+        interactable.RegisterDialogSequence(freshA);
+        interactable.RegisterDialogSequence(freshB);
+
+        Assert.Equal(2, reactor.SequenceIndex.Count);
+        Assert.Equal(2, reactor.DialogSequences.Count);
+        Assert.Same(freshA, reactor.SequenceIndex["seq_a"]);
+        Assert.Same(freshB, reactor.SequenceIndex["seq_b"]);
     }
 }

--- a/hybrasyl/Objects/Reactor.cs
+++ b/hybrasyl/Objects/Reactor.cs
@@ -198,8 +198,13 @@ public sealed class Reactor : VisibleObject, IPursuitable, ISpawnable
 
         if (Script.HasFunction("OnSpawn"))
         {
-            DialogSequences.Clear();
-            // Now run our actual OnSpawn function
+            //Reset all dialog state before re-running OnSpawn so the script re-registering its
+            //sequences doesn't trip "Dialog sequence X is being overwritten" warnings. Just clearing
+            //DialogSequences left SequenceIndex populated, which is the dictionary RegisterDialogSequence
+            //actually checks. Reactor is the second spawn (World.Insert already fires OnSpawn for any
+            //ISpawnable, then MapObject.InsertReactor calls it a second time), and ScriptProcessor.ReloadScript
+            //also re-fires OnSpawn — both paths land here.
+            (this as IPursuitable).ResetPursuits();
             var ret = Script.ExecuteFunction("OnSpawn", ScriptEnvironment.Create(("origin", this), ("source", this)));
             if (ret.Result == ScriptResult.Success)
                 Ready = true;


### PR DESCRIPTION
## Summary

Silences `Dialog sequence X is being overwritten` startup warnings (e.g. the QRM20_* spam from Abel's Meena reactor) by making `Reactor.OnSpawn` idempotent. The fix matches the `Merchant.OnSpawn` pattern already used elsewhere.

## Root cause

`Reactor.OnSpawn` cleared `DialogSequences` before re-running the script's `OnSpawn` function but left `SequenceIndex` populated. `IInteractable.RegisterDialogSequence` checks `SequenceIndex` for duplicates, so every re-registration after a second `OnSpawn` tripped a warning per registered name. Meena.lua registers 10 sequences → 10 warnings.

The double-`OnSpawn` is itself a latent issue worth a separate look:
- `World.Insert` fires `OnSpawn` for any `ISpawnable`.
- `MapObject.InsertReactor` and `MapObject.InsertNpc` then call `OnSpawn` a second time explicitly.
- `ScriptProcessor.ReloadScript` also re-fires `OnSpawn` on Lua reload.

`Merchant.OnSpawn` already calls `IPursuitable.ResetPursuits()`, which clears `Pursuits`, `DialogSequences`, **and** `SequenceIndex` together. That's why merchants don't surface this — only reactors do. This PR brings `Reactor` to the same idempotent shape, so all three trigger paths are quiet.

## Changes

- **`hybrasyl/Objects/Reactor.cs`** — replace `DialogSequences.Clear()` with `(this as IPursuitable).ResetPursuits()`. Comment explains the `SequenceIndex` invariant and the multiple call paths.
- **`Hybrasyl.Tests/Reactors.cs`** — three new tests on the existing `Reactor` test class:
  - `ResetPursuits_ClearsAllSequenceCollections` — `(this as IPursuitable).ResetPursuits()` empties all three.
  - `DialogSequencesClear_AloneLeavesSequenceIndexStale` — pins the pre-fix bug as a documented anti-pattern so future changes don't accidentally regress.
  - `ReRegisterAfterResetPursuits_LeavesNoDuplicates` — full register/reset/re-register round trip, asserts `SequenceIndex.Count == 2` with the new instances.
- **`.editorconfig` (new)** — pins `end_of_line = lf`, `charset = utf-8`, and standard indent sizes per file type. Repo currently has files committed with both CRLF and LF; this stops future edits from oscillating without forcing a one-shot mass renormalization in this PR.

## Out of scope

- The redundant explicit `OnSpawn()` calls in `MapObject.InsertReactor` / `MapObject.InsertNpc` (and the triple-call in `Creature.cs:604-606` that also passes the same Reactor through `World.Insert` twice) remain. With this PR the redundant calls are harmless (idempotent), but the wasted work and the double-ID assignment from re-`World.Insert` are still a thing. Best handled as a focused follow-up so the spawn-ordering implications can be reviewed on their own.
- One-shot CRLF→LF normalization across the repo. The `.editorconfig` change is forward-looking; a `git add --renormalize .` pass is a separate noise-only PR.

## Test plan

- [x] `dotnet test Hybrasyl.Tests` — 129/129 pass on `fix/reactor-spawn`.
- [ ] Server boot on Abel: zero `Dialog sequence QRM20_* is being overwritten` warnings (was ~10).
- [ ] In-game `/reload` of `Meena.lua` (or whatever the dev reload command is): no overwrite warnings on the second registration pass.
- [ ] Spot-check a reactor-bearing map other than Abel — confirm no new noise in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)