### PR TITLE
feat(commands): /gender and /skincolor for character-model testing

### DIFF
--- a/Hybrasyl.Tests/ChatCommands.cs
+++ b/Hybrasyl.Tests/ChatCommands.cs
@@ -1,0 +1,99 @@
+// This file is part of Project Hybrasyl.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the Affero General Public License as published by
+// the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but
+// without ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the Affero General Public License
+// for more details.
+//
+// You should have received a copy of the Affero General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>.
+
+using Hybrasyl.Subsystems.Messaging.ChatCommands;
+using Hybrasyl.Xml.Objects;
+using System.Reflection;
+using Xunit;
+
+namespace Hybrasyl.Tests;
+
+[Collection("Hybrasyl")]
+public class ChatCommands
+{
+    private static HybrasylFixture Fixture;
+
+    public ChatCommands(HybrasylFixture fixture)
+    {
+        Fixture = fixture;
+    }
+
+    //Internal command classes are dispatched via reflection by ChatCommandHandler at runtime; the
+    //test bypasses the handler's arg-parsing/auth glue and exercises the command's static Run
+    //method directly, which is where parsing and state mutation actually live.
+    private static ChatCommandResult Invoke(string commandClass, params string[] args)
+    {
+        var type = typeof(ChatCommand).Assembly.GetType(
+            $"Hybrasyl.Subsystems.Messaging.ChatCommands.{commandClass}");
+        Assert.NotNull(type);
+        var run = type!.GetMethod("Run", BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(run);
+        return (ChatCommandResult)run!.Invoke(null, new object[] { Fixture.TestUser, args })!;
+    }
+
+    [Fact]
+    public void GenderCommand_M_SetsMale()
+    {
+        Fixture.TestUser.Gender = Gender.Female;
+
+        var result = Invoke("GenderCommand", "m");
+
+        Assert.True(result.Success);
+        Assert.Equal(Gender.Male, Fixture.TestUser.Gender);
+    }
+
+    [Fact]
+    public void GenderCommand_FemaleAlias_SetsFemale()
+    {
+        Fixture.TestUser.Gender = Gender.Male;
+
+        var result = Invoke("GenderCommand", "female");
+
+        Assert.True(result.Success);
+        Assert.Equal(Gender.Female, Fixture.TestUser.Gender);
+    }
+
+    [Fact]
+    public void GenderCommand_CaseInsensitive()
+    {
+        Fixture.TestUser.Gender = Gender.Female;
+
+        var result = Invoke("GenderCommand", "MALE");
+
+        Assert.True(result.Success);
+        Assert.Equal(Gender.Male, Fixture.TestUser.Gender);
+    }
+
+    [Fact]
+    public void GenderCommand_RejectsNeutral()
+    {
+        Fixture.TestUser.Gender = Gender.Male;
+
+        var result = Invoke("GenderCommand", "neutral");
+
+        Assert.False(result.Success);
+        Assert.Equal(Gender.Male, Fixture.TestUser.Gender);
+    }
+
+    [Fact]
+    public void GenderCommand_RejectsGarbage()
+    {
+        Fixture.TestUser.Gender = Gender.Male;
+
+        var result = Invoke("GenderCommand", "potato");
+
+        Assert.False(result.Success);
+        Assert.Equal(Gender.Male, Fixture.TestUser.Gender);
+    }
+}

--- a/Hybrasyl.Tests/ChatCommands.cs
+++ b/Hybrasyl.Tests/ChatCommands.cs
@@ -12,6 +12,7 @@
 // You should have received a copy of the Affero General Public License along
 // with this program. If not, see <http://www.gnu.org/licenses/>.
 
+using Hybrasyl.Internals.Enums;
 using Hybrasyl.Subsystems.Messaging.ChatCommands;
 using Hybrasyl.Xml.Objects;
 using System.Reflection;
@@ -95,5 +96,60 @@ public class ChatCommands
 
         Assert.False(result.Success);
         Assert.Equal(Gender.Male, Fixture.TestUser.Gender);
+    }
+
+    [Fact]
+    public void SkinColorCommand_NamedRangeSetsEnum()
+    {
+        Fixture.TestUser.SkinColor = SkinColor.Basic;
+
+        var result = Invoke("SkinColorCommand", "3");
+
+        Assert.True(result.Success);
+        Assert.Equal(SkinColor.Orc, Fixture.TestUser.SkinColor);
+    }
+
+    [Fact]
+    public void SkinColorCommand_AcceptsByteMax()
+    {
+        Fixture.TestUser.SkinColor = SkinColor.Basic;
+
+        var result = Invoke("SkinColorCommand", "255");
+
+        Assert.True(result.Success);
+        Assert.Equal((byte)255, (byte)Fixture.TestUser.SkinColor);
+    }
+
+    [Fact]
+    public void SkinColorCommand_RejectsAboveByteMax()
+    {
+        Fixture.TestUser.SkinColor = SkinColor.Tan;
+
+        var result = Invoke("SkinColorCommand", "256");
+
+        Assert.False(result.Success);
+        Assert.Equal(SkinColor.Tan, Fixture.TestUser.SkinColor);
+    }
+
+    [Fact]
+    public void SkinColorCommand_RejectsNegative()
+    {
+        Fixture.TestUser.SkinColor = SkinColor.Tan;
+
+        var result = Invoke("SkinColorCommand", "-1");
+
+        Assert.False(result.Success);
+        Assert.Equal(SkinColor.Tan, Fixture.TestUser.SkinColor);
+    }
+
+    [Fact]
+    public void SkinColorCommand_RejectsNonNumeric()
+    {
+        Fixture.TestUser.SkinColor = SkinColor.Tan;
+
+        var result = Invoke("SkinColorCommand", "abc");
+
+        Assert.False(result.Success);
+        Assert.Equal(SkinColor.Tan, Fixture.TestUser.SkinColor);
     }
 }

--- a/hybrasyl/Subsystems/Messaging/ChatCommands/GenderCommand.cs
+++ b/hybrasyl/Subsystems/Messaging/ChatCommands/GenderCommand.cs
@@ -1,0 +1,45 @@
+// This file is part of Project Hybrasyl.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the Affero General Public License as published by
+// the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but
+// without ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the Affero General Public License
+// for more details.
+//
+// You should have received a copy of the Affero General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>.
+
+using Hybrasyl.Objects;
+using Hybrasyl.Xml.Objects;
+
+namespace Hybrasyl.Subsystems.Messaging.ChatCommands;
+
+internal class GenderCommand : ChatCommand
+{
+    public new static string Command = "gender";
+    public new static string ArgumentText = "<m|f>";
+    public new static string HelpText = "Set your character's gender to Male (m) or Female (f). Player characters cannot be Neutral.";
+    public new static bool Privileged = true;
+
+    public new static ChatCommandResult Run(User user, params string[] args)
+    {
+        var input = args[0].ToLowerInvariant();
+        var gender = input switch
+        {
+            "m" or "male" => Gender.Male,
+            "f" or "female" => Gender.Female,
+            _ => (Gender?)null
+        };
+
+        if (gender is null)
+            return Fail($"Unknown gender '{args[0]}'. Use 'm' / 'male' or 'f' / 'female'.");
+
+        user.Gender = gender.Value;
+        user.SendUpdateToUser();
+        user.Show();
+        return Success($"Gender set to {gender.Value}.");
+    }
+}

--- a/hybrasyl/Subsystems/Messaging/ChatCommands/SkinColorCommand.cs
+++ b/hybrasyl/Subsystems/Messaging/ChatCommands/SkinColorCommand.cs
@@ -1,0 +1,39 @@
+// This file is part of Project Hybrasyl.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the Affero General Public License as published by
+// the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but
+// without ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the Affero General Public License
+// for more details.
+//
+// You should have received a copy of the Affero General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>.
+
+using Hybrasyl.Internals.Enums;
+using Hybrasyl.Objects;
+
+namespace Hybrasyl.Subsystems.Messaging.ChatCommands;
+
+internal class SkinColorCommand : ChatCommand
+{
+    public new static string Command = "skincolor";
+    public new static string ArgumentText = "<byte 0-255>";
+    public new static string HelpText =
+        "Set your character's skin color sprite — the mm##.epf / wm##.epf variant from khan{m,w}im. "
+        + "Enum names cover 0-9 (Basic..Purple); the wire byte addresses 0-255 for arbitrary client-side variants.";
+    public new static bool Privileged = true;
+
+    public new static ChatCommandResult Run(User user, params string[] args)
+    {
+        if (!byte.TryParse(args[0], out var value))
+            return Fail($"Could not parse '{args[0]}' as byte (0-255).");
+
+        user.SkinColor = (SkinColor)value;
+        user.SendUpdateToUser();
+        user.Show();
+        return Success($"Skin color set to {value} ({user.SkinColor}).");
+    }
+}


### PR DESCRIPTION
## Summary

Two admin slash commands for testing how the character model renders, plus a docs/memory note pinning the body-byte semantics that the investigation surfaced.

- **`/gender <m|f>`** — sets `User.Gender` to `Male` or `Female`. Case-insensitive (`m`/`male`/`f`/`female`). Player characters cannot be `Gender.Neutral`; that value exists in the Hybrasyl.Xml enum for non-player contexts but is rejected here.
- **`/skincolor <byte 0-255>`** — sets `User.SkinColor`. That's the byte at [DisplayUser.cs:77](hybrasyl/Networking/ServerPackets/DisplayUser.cs#L77) which selects which `mm##.epf` / `wm##.epf` variant the client loads from `khanmim` / `khanwim`. Enum names cover 0-9 (Basic..Purple); the wire is `byte`, so the command accepts the full 0-255 range to poke at whatever palette/sprite the client has at any given index. This same byte will eventually be repurposed for species body style.

## Investigation note

An earlier attempt added a separate `User.BodyStyle` property feeding the body byte's low nibble. That nibble is actually `PantsColor` (per the modern Chaos.Server decoder), not a body-model variant — so the visual didn't change in smoke testing. The fix turned out to be simpler than expected: the mm/wm variant is already carried by the existing `SkinColor` byte, and `User.SkinColor` already exists as a `[JsonProperty]`. The reverted attempt is mentioned in the gender commit body for archaeology purposes.

## Out of scope

- Body-model variants beyond what's already wired (Male / Female / Ghost / Invis / Jester etc. — those are state-driven via `Gender` + `Condition.Alive` / `Condition.IsInvisible`, not a player-controlled selector).
- Wider species/sprite redesign that will eventually repurpose the SkinColor byte. The slash-command surface is forward-compatible since it already accepts the full byte range.
- Any wire-protocol changes — both fields used here already exist on the wire.

## Test plan

- [x] `dotnet test Hybrasyl.Tests` — 136/136 pass on `feat/slash-commands` (10 new tests across both commands).
- [x] In-game smoke test:
  - `/gender m` and `/gender f` toggle the rendered body category cleanly.
  - `/skincolor N` (for various N in 0-9) cycles through the named palette variants.
- [ ] Try `/skincolor 100`+ in a build that has the wider sprite range loaded, to confirm the wire byte addresses the full client-side range (no server-side clamp).
- [ ] Confirm both changes persist across logout/login (both fields are `[JsonProperty]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)