### PR TITLE
fix: OOB creature spawning, AoI null-deref races, and status removal chain

### DIFF
--- a/Hybrasyl.Tests/Statuses.cs
+++ b/Hybrasyl.Tests/Statuses.cs
@@ -18,6 +18,7 @@
 
 using Hybrasyl.Objects;
 using Hybrasyl.Subsystems.Scripting;
+using Hybrasyl.Subsystems.Statuses;
 using Hybrasyl.Xml.Objects;
 using System;
 using System.Linq;
@@ -272,6 +273,10 @@ public class Status
         Fixture.ResetTestUserStats();
         Fixture.ResetSecondTestUserStats();
 
+        // Bump the remover's level so TestScalingCurse.RemoveChance formula
+        // (min(0.97, 0.35 + (SOURCELEVEL/(TARGETLEVEL+10))/1.5)) caps at 0.97.
+        // The remaining ~3% flake rate is acknowledged in the loose-ends plan.
+        Fixture.TestUser.Stats.Level = 99;
         Fixture.TestUser.SetCookie("combatlog", "on");
         Fixture.SecondTestUser.SetCookie("combatlog", "on");
 
@@ -310,5 +315,73 @@ public class Status
         Assert.True(statusEvent.StatusName == "TestScalingCurse", "Status name does not match");
 
 
+    }
+
+    [Fact]
+    public void RemoveStatusWithRemovalChanceFails()
+    {
+        Fixture.ResetTestUserStats();
+        Fixture.ResetSecondTestUserStats();
+        Fixture.TestUser.RemoveAllStatuses();
+
+        Assert.True(Game.World.WorldData.TryGetValue<Creature>("Gabbaghoul", out var monsterXml),
+            "Gabbaghoul test monster not found");
+        Assert.True(Game.World.WorldData.TryGetValue<Hybrasyl.Xml.Objects.Status>("TestFailCurse", out var failXml),
+            "Status TestFailCurse not found");
+
+        Fixture.TestUser.Teleport("XUnit Test Realm", 10, 10);
+        var monster = new Monster(monsterXml, SpawnFlags.AiDisabled, 99) { X = 11, Y = 11 };
+        Fixture.TestUser.Map.InsertMonster(monster);
+
+        // Apply the curse with the monster as source so OriginSnapshotId is populated
+        // and the RemoveChance roll actually evaluates.
+        var status = new CreatureStatus(failXml, Fixture.TestUser, null, monster);
+        Fixture.TestUser.ApplyStatus(status);
+        Assert.Contains(Fixture.TestUser.CurrentStatuses.Values, s => s.Name == "TestFailCurse");
+
+        // RemoveChance="0" means chance >= 0 is always true, so removal should always fail.
+        var removed = Fixture.TestUser.RemoveStatus(status.Icon, true, Fixture.SecondTestUser);
+        Assert.False(removed, "Removal should have failed but succeeded");
+        Assert.Contains(Fixture.TestUser.CurrentStatuses.Values, s => s.Name == "TestFailCurse");
+        Assert.Equal("You try your best, but nothing happens.", Fixture.SecondTestUser.LastSystemMessage);
+
+        // Combat-log entry should reflect the failed roll
+        Assert.True(Fixture.SecondTestUser.CombatEvents.TryPop(out var ev));
+        var statusEvent = Assert.IsType<StatusEvent>(ev);
+        Assert.Equal("TestFailCurse", statusEvent.StatusName);
+        Assert.True(statusEvent.RemovalRoll >= statusEvent.RequiredRoll,
+            "Failed removal should have RemovalRoll >= RequiredRoll");
+    }
+
+    [Fact]
+    public void StatusExpiryIsSilent()
+    {
+        Fixture.ResetTestUserStats();
+        Fixture.TestUser.RemoveAllStatuses();
+
+        var invisible = Game.World.WorldData.Find<Castable>(condition: x => x.Name == "TestAddInvisible")
+            .FirstOrDefault();
+        Assert.NotNull(invisible);
+
+        Assert.True(Fixture.TestUser.UseCastable(invisible, Fixture.TestUser));
+        Assert.True(Fixture.TestUser.Condition.IsInvisible);
+
+        // Sentinel set before natural expiry so we can detect whether the
+        // success message ("You succeed in removing the affliction.") fires.
+        const string sentinel = "__expiry-sentinel__";
+        Fixture.TestUser.SendSystemMessage(sentinel);
+
+        // TestAddInvisible has Duration=1 — wait for it to expire, then drive
+        // the tick manually since the StatusTickJob isn't scheduled in tests.
+        Assert.True(TestHelpers.WaitFor(() =>
+                Fixture.TestUser.CurrentStatuses.Values.All(s => s.Expired)),
+            "Status did not reach Expired state within timeout");
+        Fixture.TestUser.ProcessStatusTicks();
+
+        // OnExpire should clear the Invisible condition, but no removal-success
+        // system message should be emitted (remover is null on natural expiry).
+        Assert.Equal(0, Fixture.TestUser.CurrentStatuses.Count);
+        Assert.False(Fixture.TestUser.Condition.IsInvisible);
+        Assert.NotEqual("You succeed in removing the affliction.", Fixture.TestUser.LastSystemMessage);
     }
 }

--- a/hybrasyl/Interfaces/ICreatureSnapshot.cs
+++ b/hybrasyl/Interfaces/ICreatureSnapshot.cs
@@ -22,7 +22,7 @@ namespace Hybrasyl.Interfaces
                 CreatureGuid = Guid,
                 Stats = statInfo ?? new StatInfo()
             };
-            World.WorldState.Set(Guid, snapshot);
+            World.WorldState.Set(snapshot.Guid, snapshot);
             return snapshot.Guid;
         }
     }

--- a/hybrasyl/Objects/Creature.cs
+++ b/hybrasyl/Objects/Creature.cs
@@ -1444,7 +1444,7 @@ public class Creature : VisibleObject, IStatSnapshotProvider
             Applied = false // this is a removal
         };
 
-        if (string.IsNullOrEmpty(status.RemoveChance))
+        if (!string.IsNullOrEmpty(status.RemoveChance))
         {
             var snapshot = World.WorldState.Get<CreatureSnapshot>(status.OriginSnapshotId);
 
@@ -1481,8 +1481,13 @@ public class Creature : VisibleObject, IStatSnapshotProvider
         foreach (var reactor in Map.EntityTree.GetObjects(GetViewport()).OfType<Reactor>())
             if (reactor.VisibleToStatuses?.Contains(status.Name) ?? false)
                 reactor.AoiDeparture(this);
-        u.SendSystemMessage("You succeed in removing the affliction.");
-        u.SendCombatLogMessage(statusEvent);
+        // Only announce removal when a remover actively triggered it; natural
+        // expiry (ProcessStatusTicks passes remover=null) should be silent.
+        if (remover != null)
+        {
+            u.SendSystemMessage("You succeed in removing the affliction.");
+            u.SendCombatLogMessage(statusEvent);
+        }
         return true;
     }
 

--- a/hybrasyl/Objects/Creature.cs
+++ b/hybrasyl/Objects/Creature.cs
@@ -713,7 +713,7 @@ public class Creature : VisibleObject, IStatSnapshotProvider
                         var toRemove = tar.CurrentStatuses.Values.FirstOrDefault(predicate: s =>
                             s.Category.Contains(status.Value));
                         if (toRemove == null) break;
-                        tar.RemoveStatus(toRemove.Icon);
+                        tar.RemoveStatus(toRemove.Icon, remover: this);
                         GameLog.UserActivityInfo(
                             $"UseCastable: {Name} casting {castableXml.Name} - removing status category {status.Value}");
                     }
@@ -722,7 +722,7 @@ public class Creature : VisibleObject, IStatSnapshotProvider
                 {
                     GameLog.UserActivityError(
                         $"UseCastable: {Name} casting {castableXml.Name} - removing status {status}");
-                    tar.RemoveStatus(applyStatus.Icon);
+                    tar.RemoveStatus(applyStatus.Icon, remover: this);
 
                 }
                 else

--- a/hybrasyl/Objects/Creature.cs
+++ b/hybrasyl/Objects/Creature.cs
@@ -1446,28 +1446,36 @@ public class Creature : VisibleObject, IStatSnapshotProvider
 
         if (!string.IsNullOrEmpty(status.RemoveChance))
         {
-            var snapshot = World.WorldState.Get<CreatureSnapshot>(status.OriginSnapshotId);
-
-            var result = FormulaParser.Eval(status.RemoveChance, new FormulaEvaluation
+            if (World.WorldState.TryGetValue<CreatureSnapshot>(status.OriginSnapshotId, out var snapshot))
             {
-                OriginalCaster = snapshot.Stats,
-                Target = this,
-                Source = remover,
-            });
-
-            var chance = Random.Shared.NextDouble();
-
-            statusEvent.RemovalRoll = chance;
-            statusEvent.RequiredRoll = result;
-
-            if (chance >= result)
-            {
-                if (remover is User user)
+                var result = FormulaParser.Eval(status.RemoveChance, new FormulaEvaluation
                 {
-                    user.SendSystemMessage("You try your best, but nothing happens.");
-                    user.SendCombatLogMessage(statusEvent);
+                    OriginalCaster = snapshot.Stats,
+                    Target = this,
+                    Source = remover,
+                });
+
+                var chance = Random.Shared.NextDouble();
+
+                statusEvent.RemovalRoll = chance;
+                statusEvent.RequiredRoll = result;
+
+                if (chance >= result)
+                {
+                    if (remover is User user)
+                    {
+                        user.SendSystemMessage("You try your best, but nothing happens.");
+                        user.SendCombatLogMessage(statusEvent);
+                    }
+                    return false;
                 }
-                return false;
+            }
+            else
+            {
+                // Snapshot missing (status applied without a source, or snapshot
+                // evicted). Skip the chance roll and proceed with removal.
+                GameLog.Warning(
+                    $"RemoveStatus: no origin snapshot for {status.Name} on {Name} (id={status.OriginSnapshotId}); skipping chance roll");
             }
         }
 

--- a/hybrasyl/Objects/ItemObject.cs
+++ b/hybrasyl/Objects/ItemObject.cs
@@ -473,7 +473,7 @@ public class ItemObject : VisibleObject, IInteractable
                     {
                         GameLog.UserActivityInfo(
                             $"Invoke: {trigger.Name} using {Name} - applying status {add.Value} - duration {duration}");
-                        trigger.ApplyStatus(new CreatureStatus(applyStatus, trigger, null, null, duration, tick,
+                        trigger.ApplyStatus(new CreatureStatus(applyStatus, trigger, null, trigger, duration, tick,
                             add.Intensity));
                     }
                 }

--- a/hybrasyl/Objects/MapObject.cs
+++ b/hybrasyl/Objects/MapObject.cs
@@ -60,8 +60,8 @@ public class MapObject : IStateStorable
 
         LoadMapFile();
         LoadXml(newMap);
-        for (byte x = 0; x <= X; x++)
-            for (byte y = 0; y <= Y; y++)
+        for (byte x = 0; x < X; x++)
+            for (byte y = 0; y < Y; y++)
             {
                 if (IsWall(x, y)) continue;
                 UsableTiles.Add((x, y));
@@ -683,14 +683,19 @@ public class MapObject : IStateStorable
         {
             for (var x = -1 * radius; x <= radius; x++)
                 for (var y = -1 * radius; y <= radius; y++)
-                    if (IsWall(xStart + x, yStart + y) ||
-                        GetTileContents(xStart + x, yStart + y).Where(predicate: x => x is Creature).Count() > 0) { }
+                {
+                    var nx = xStart + x;
+                    var ny = yStart + y;
+                    if (!IsValidPoint((short)nx, (short)ny)) continue;
+                    if (IsWall(nx, ny) ||
+                        GetTileContents(nx, ny).Where(predicate: x => x is Creature).Count() > 0) { }
                     else
                     {
-                        retx = (byte)(xStart + x);
-                        rety = (byte)(yStart + y);
+                        retx = (byte)nx;
+                        rety = (byte)ny;
                         break;
                     }
+                }
 
             radius++;
             // Don't go on forever here

--- a/hybrasyl/Objects/Monster.cs
+++ b/hybrasyl/Objects/Monster.cs
@@ -102,18 +102,21 @@ public sealed class Monster : Creature, ICloneable, IEphemeral, ISpawnable
         }
     }
 
-    public LocationInfo RandomDestination => new()
+    public LocationInfo RandomDestination
     {
-        X = (byte) Math.Clamp(X + Random.Shared.Next(
-                (int) (Game.ActiveConfiguration.Constants.ViewportSize * -0.5),
-                (int) (Game.ActiveConfiguration.Constants.ViewportSize * 0.5)), byte.MinValue,
-            byte.MaxValue),
-        Y = (byte) Math.Clamp(X + Random.Shared.Next(
-                (int) (Game.ActiveConfiguration.Constants.ViewportSize * -0.5),
-                (int) (Game.ActiveConfiguration.Constants.ViewportSize * 0.5)), byte.MinValue,
-            byte.MaxValue),
-        MapId = Map.Id
-    };
+        get
+        {
+            var halfVp = (int)(Game.ActiveConfiguration.Constants.ViewportSize * 0.5);
+            var dx = Random.Shared.Next(-halfVp, halfVp);
+            var dy = Random.Shared.Next(-halfVp, halfVp);
+            return new LocationInfo
+            {
+                X = (byte)Math.Clamp(X + dx, 0, Map.X - 1),
+                Y = (byte)Math.Clamp(Y + dy, 0, Map.Y - 1),
+                MapId = Map.Id
+            };
+        }
+    }
 
     public double ActiveSeconds
     {
@@ -1151,7 +1154,12 @@ public sealed class Monster : Creature, ICloneable, IEphemeral, ISpawnable
                 }
             }
 
-            if (Map.EntityTree.GetObjects(GetViewport()).OfType<User>().ToList().Count == 0) Active = false;
+            // Map can be null if this monster was removed from its map on another thread
+            // between the caller's viewport snapshot and our invocation here.
+            var map = Map;
+            if (map != null &&
+                map.EntityTree.GetObjects(GetViewport()).OfType<User>().ToList().Count == 0)
+                Active = false;
 
             base.AoiDeparture(obj);
         }
@@ -1163,7 +1171,10 @@ public sealed class Monster : Creature, ICloneable, IEphemeral, ISpawnable
         {
             if (obj is User user && (!user.Condition.IsInvisible || Condition.SeeInvisible))
             {
-                if (Map.EntityTree.GetObjects(GetViewport()).OfType<User>().ToList().Count > 0) Active = true;
+                var map = Map;
+                if (map != null &&
+                    map.EntityTree.GetObjects(GetViewport()).OfType<User>().ToList().Count > 0)
+                    Active = true;
 
                 if (IsHostile(user))
                 {

--- a/hybrasyl/Objects/VisibleObject.cs
+++ b/hybrasyl/Objects/VisibleObject.cs
@@ -178,6 +178,8 @@ public class VisibleObject : WorldObject, IVisible
 
         foreach (var obj in withinViewport)
         {
+            // Skip objects that were removed from their map between the snapshot and now
+            if (obj.Map == null) continue;
             GameLog.DebugFormat("Object type is {0} and its name is {1}", obj.GetType(), obj.Name);
             obj.AoiEntry(this);
         }
@@ -190,6 +192,7 @@ public class VisibleObject : WorldObject, IVisible
 
         foreach (var obj in withinViewport)
         {
+            if (obj.Map == null) continue;
             GameLog.DebugFormat("Object type is {0} and its name is {1}", obj.GetType(), obj.Name);
             obj.AoiDeparture(this);
         }

--- a/hybrasyl/Subsystems/Formulas/FormulaParser.cs
+++ b/hybrasyl/Subsystems/Formulas/FormulaParser.cs
@@ -68,8 +68,7 @@ internal static class FormulaParser
                 e.Parameters[$"SOURCE{prop.Name.ToUpper()}"] = prop.GetValue(eval.Source);
             if (eval.Target != null)
                 e.Parameters[$"TARGET{prop.Name.ToUpper()}"] = prop.GetValue(eval.Target);
-            if (eval.OriginalCaster != null)
-                e.Parameters[$"ORIGINALCASTER{prop.Name.ToUpper()}"] = prop.GetValue(eval.OriginalCaster);
+            // OriginalCaster is a StatInfo, not a Creature — only the StatInfo loop applies to it.
         }
 
         foreach (var prop in FormulaTokens[typeof(Castable)].Where(prop => eval.Castable != null))

--- a/hybrasyl/Subsystems/Messaging/ChatCommands/StatusCommand.cs
+++ b/hybrasyl/Subsystems/Messaging/ChatCommands/StatusCommand.cs
@@ -36,7 +36,7 @@ internal class StatusCommand : ChatCommand
             var duration = xmlStatus.Duration;
             if (args.Length > 1 && int.TryParse(args[1], out var duroverride))
                 duration = duroverride;
-            var status = new CreatureStatus(xmlStatus, user, null, null, duration);
+            var status = new CreatureStatus(xmlStatus, user, null, user, duration);
             user.ApplyStatus(status);
             return Success($"Status {xmlStatus.Name} applied for {duration} seconds");
         }

--- a/hybrasyl/Subsystems/Scripting/HybrasylMonster.cs
+++ b/hybrasyl/Subsystems/Scripting/HybrasylMonster.cs
@@ -174,7 +174,7 @@ public class HybrasylMonster : HybrasylWorldObject
             return false;
         }
 
-        return Monster.ApplyStatus(new CreatureStatus(status, Monster, null, null,
+        return Monster.ApplyStatus(new CreatureStatus(status, Monster, null, Monster,
             duration == 0 ? status.Duration : duration,
             tick == 0 ? status.Tick : tick,
             intensity));

--- a/hybrasyl/Subsystems/Scripting/HybrasylUser.cs
+++ b/hybrasyl/Subsystems/Scripting/HybrasylUser.cs
@@ -1418,7 +1418,7 @@ public class HybrasylUser : HybrasylWorldObject
             return false;
         }
 
-        return User.ApplyStatus(new CreatureStatus(status, User, null, null,
+        return User.ApplyStatus(new CreatureStatus(status, User, null, User,
             duration == 0 ? status.Duration : duration,
             tick == 0 ? status.Tick : tick,
             intensity));

--- a/hybrasyl/Subsystems/Spawning/Monolith.cs
+++ b/hybrasyl/Subsystems/Spawning/Monolith.cs
@@ -314,6 +314,10 @@ internal class Monolith
                     baseMob.X = (byte)xcoord;
                     baseMob.Y = (byte)ycoord;
 
+                    if (!spawnmap.IsValidPoint(baseMob.X, baseMob.Y))
+                        GameLog.SpawnError(
+                            $"OOB spawn: {spawn.Name} placed at {baseMob.X},{baseMob.Y} on {spawnmap.Name} ({spawnmap.X}x{spawnmap.Y}) - source={(spawn.Coordinates.Count != 0 ? "xml" : "FindEmptyTile")}");
+
                     if (spawn.Hostility != null)
                         baseMob.Hostility = spawn.Hostility;
 


### PR DESCRIPTION
## Summary

Started with a creature-OOB regression and an AoI NRE on stealth — uncovered a chain of latent bugs in the status removal/RemoveChance feature along the way. Five commits, organized by concern in case any need to split out.

- **`7c84e71` — spawn / AoI fixes**
  - `MapObject.UsableTiles` init loop used `<= X/Y` instead of `< X/Y`, so the off-by-one column/row (which had no collision data) were eligible for `FindEmptyTile`. Random spawns landed at `Map.X` / `Map.Y` (OOB).
  - `RandomDestination` on Monster had a copy-paste typo (Y used X as base) and clamped to `byte.MaxValue` instead of `Map.X-1`/`Map.Y-1`. A* / `Walk` already bound-checked so mobs didn't actually walk OOB, but the wander AI churned hopeless paths.
  - `FindEmptyTile(byte,byte)` overload gained an `IsValidPoint` guard for defense in depth.
  - `Monster.AoiEntry` / `AoiDeparture` (and `VisibleObject.Hide` / `Show`) NRE'd when a monster was removed from its map between a viewport snapshot and the iteration that fired AoI callbacks. Confirmed in three traces (Refresh / Hide / Teleport). Map access is now null-guarded at the callback site, with a defense-in-depth skip in the AoI walker.
  - Added a `SpawnError` guard in `Monolith` that logs source (xml vs `FindEmptyTile`) for any OOB placement that still escapes — so future regressions are caught.

- **`0af79b0` — status removal: success message + RemoveChance guard**
  - Success message ("You succeed in removing the affliction.") now only fires when `remover != null`. Natural expiry from `ProcessStatusTicks` is silent again.
  - Inverted `RemoveChance` guard fixed: was running the chance roll on statuses *without* one configured and skipping the roll on those *with* one. The whole feature was an effective no-op.

- **`97ea2e2` — tolerate missing origin snapshot**
  - `WorldStateStore.Get<T>` throws on miss. Switched to `TryGetValue` and log a warning + permissive removal when the snapshot can't be found. Was crashing stealth break with `KeyNotFoundException` after the previous commit made the snapshot lookup actually run.

- **`1acb216` — make RemoveChance evaluation actually work end-to-end**
  - `CreateStatSnapshot` stored snapshots under the *creature's* Guid but returned the *snapshot's* Guid, so every lookup against `OriginSnapshotId` missed. Store under `snapshot.Guid`.
  - `FormulaParser.Parameterize` had a copy-paste bug: the Creature-type loop tried to read Creature properties off `eval.OriginalCaster` (which is `StatInfo`), throwing `TargetException` as soon as a formula ran.
  - `Creature.UseCastable`'s RemoveStatuses loop called `tar.RemoveStatus(icon)` without a remover. Now passes `this` so the chance formula's `SOURCE*` variables are populated.
  - Scripting `HybrasylUser`/`HybrasylMonster`, `ItemObject` passive triggers, and the `/status` chat command now pass the target as `source` when no caster is known, so self-applied statuses (hide, cruth oiche, item buffs, GM-applied) get a populated `OriginSnapshotId` and their RemoveChance formulas can evaluate against a real `OriginalCaster.Stats`.

- **`2921fea` — tests**
  - `RemoveStatusWithRemovalChanceFails` uses ceridwen's `TestFailCurse` (`RemoveChance=0`) to deterministically exercise the failure branch.
  - `StatusExpiryIsSilent` applies `TestAddInvisible`, waits for `Expired`, drives `ProcessStatusTicks` manually (the tick job isn't scheduled in tests), and asserts no removal-success message fires.
  - Existing `RemoveStatusWithRemovalChance` now bumps `TestUser.Stats.Level = 99` so the now-actually-evaluating scaling formula caps at 0.97 and the test stays at ~3% flake instead of 59% at default test levels.

## Dependencies

Ceridwen has two changes pushed on `main`:
- `e115220` add `TestFailCurse` status XML (`RemoveChance=0`)
- `c101e7e` fix `TestScalingCurse` formula syntax (extra paren + lowercase `min` → `Min`)

These syntax errors were latent — the inverted `RemoveChance` guard skipped evaluation, so neither ever broke before. With the server-side bugs fixed, the formula actually runs.

## Test plan

- [x] `dotnet build hybrasyl/Hybrasyl.csproj` clean (only pre-existing warnings)
- [x] `dotnet test Hybrasyl.Tests/` 141/141 across 3 consecutive runs
- [x] In-game repro for OOB / AoI NRE confirmed cleared by user
- [x] In-game repro for stealth break: `cruth oiche`/`hide` → spacebar or BreakStealth-able ability should clear the underlying status without a `KeyNotFoundException` and without spurious "You succeed in removing the affliction." on natural expiry

🤖 Generated with [Claude Code](https://claude.com/claude-code)